### PR TITLE
Make metric mapping correct under churn, races, and counter semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Kafka SPI cumulative counters (metrics named `*-total`) are now exported as
+  monotonic OTLP Sums instead of gauges, so PromQL `rate()` over them is
+  semantically correct. All other SPI metrics remain gauges.
+
+### Fixed
+
+- A metric value that flips to non-finite/non-numeric between snapshot and
+  mapping no longer drops the entire export batch. Values are captured once at
+  snapshot time, which also halves the `synchronized` `metricValue()` reads per
+  tick.
+- Per-metric rendering/name/scope caches are pruned to the live metric set on the
+  export thread, fixing two unbounded leaks under metric/topic churn (the Yammer
+  scope-attribute cache and a removal-vs-export race on the SPI rendering cache)
+  and keeping all cache maintenance off Kafka's metric-callback path.
+- Cumulative-counter `startEpochNanos` stays stable across a `contextChange`
+  mapper rebuild, so a label change no longer looks like a counter reset to
+  downstream tools.
+
 ### Added
 
 - Initial release of the OTLP-native Kafka `MetricsReporter` plugin

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ cd monedula-metrics-reporter
 
 ## How it works
 
-Kafka calls `metricChange()` synchronously when a metric is added or updated. The plugin stores the metric in a `ConcurrentHashMap` (after applying any allow-list regex filter) — no I/O on the calling thread. A daemon scheduler thread periodically snapshots the registry, maps each metric to an OTel gauge `MetricData`, and exports the batch to the collector. If the collector is unreachable, the export call fails silently after its timeout, the batch is dropped, and the next tick starts fresh — no retry queue, no memory growth, no impact on Kafka.
+Kafka calls `metricChange()` synchronously when a metric is added or updated. The plugin stores the metric in a `ConcurrentHashMap` (after applying any allow-list regex filter) — no I/O on the calling thread. A daemon scheduler thread periodically snapshots the registry, maps each metric to OTel `MetricData` (cumulative `*-total` metrics as monotonic Sums, the rest as gauges), and exports the batch to the collector. If the collector is unreachable, the export call fails silently after its timeout, the batch is dropped, and the next tick starts fresh — no retry queue, no memory growth, no impact on Kafka.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,8 +31,9 @@ flowchart LR
   and returns numeric, finite values during snapshot.
 - `YammerMetricRegistry` attaches to Kafka's Yammer registry when broker classes
   are present and stores allow-listed broker-internal metrics.
-- `MetricDataMapper` converts Kafka SPI metrics to OpenTelemetry gauge
-  `MetricData`.
+- `MetricDataMapper` converts Kafka SPI metrics to OpenTelemetry `MetricData`:
+  cumulative `*-total` counters become monotonic Sums (so PromQL `rate()` is
+  correct), everything else becomes a gauge.
 - `YammerMetricDataMapper` converts Yammer gauges, counters, meters, timers,
   and histograms to OpenTelemetry metric data.
 - `MetricCollector` runs a single daemon scheduler thread that snapshots both

--- a/src/main/java/dev/monedula/metricsreporter/MetricDataMapper.java
+++ b/src/main/java/dev/monedula/metricsreporter/MetricDataMapper.java
@@ -2,14 +2,18 @@
 // Copyright (C) 2025 Monedula contributors
 package dev.monedula.metricsreporter;
 
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -19,21 +23,35 @@ public class MetricDataMapper {
     private final Resource resource;
     private final String namespace;
     /**
+     * Constant start-of-process time used as {@code startEpochNanos} for every CUMULATIVE
+     * Sum point (the {@code *-total} counters). Captured once so the start time stays
+     * stable across export ticks — and threaded through {@code contextChange} mapper
+     * rebuilds (see {@link OtlpMetricReporter}) so a label change doesn't look like a
+     * counter reset to PromQL {@code rate()}.
+     */
+    private final long startEpochNanos;
+    /**
      * Per-{@link MetricName} cached {@link MetricRendering} — formatted name + Attributes
-     * bundle. Inputs (tags, namespace, formatter rules) are immutable for a metric's
-     * lifetime, so a tick that re-encounters a previously-seen metric just reads from
-     * here instead of rebuilding the {@link io.opentelemetry.api.common.Attributes} +
-     * sanitising the name. {@link MetricRegistry} drives eviction via its listener.
+     * bundle + counter/gauge classification. Inputs (tags, namespace, formatter rules) are
+     * immutable for a metric's lifetime, so a tick that re-encounters a previously-seen
+     * metric just reads from here. Entries for removed metrics are pruned in {@link #mapAll}
+     * by retaining only the live snapshot's names — so invalidation happens on the export
+     * thread, never on Kafka's hot metric-removal callback path.
      */
     private final ConcurrentHashMap<MetricName, MetricRendering> renderingCache = new ConcurrentHashMap<>();
 
     public MetricDataMapper(Map<String, String> resourceAttributes) {
-        this("", resourceAttributes);
+        this("", resourceAttributes, System.currentTimeMillis() * 1_000_000L);
     }
 
     public MetricDataMapper(String namespace, Map<String, String> resourceAttributes) {
+        this(namespace, resourceAttributes, System.currentTimeMillis() * 1_000_000L);
+    }
+
+    public MetricDataMapper(String namespace, Map<String, String> resourceAttributes, long startEpochNanos) {
         this.namespace = namespace == null ? "" : namespace;
         this.resource = ResourceFactory.create(resourceAttributes);
+        this.startEpochNanos = startEpochNanos;
     }
 
     /**
@@ -45,6 +63,16 @@ public class MetricDataMapper {
         return resource;
     }
 
+    /** Stable cumulative-counter start time; threaded into rebuilt mappers to avoid reset signals. */
+    public long startEpochNanos() {
+        return startEpochNanos;
+    }
+
+    /**
+     * Map a single live metric. Reads {@link KafkaMetric#metricValue()} and throws on a
+     * non-numeric / non-finite value — used only for direct callers (tests). The export
+     * path goes through {@link #mapAll(List)} with values already captured at snapshot time.
+     */
     public MetricData map(KafkaMetric metric) {
         Object raw = metric.metricValue();
         if (!(raw instanceof Number)) {
@@ -54,9 +82,33 @@ public class MetricDataMapper {
         if (!Double.isFinite(value)) {
             throw new IllegalArgumentException("Non-finite metric value for " + metric.metricName() + ": " + value);
         }
-        long now = System.currentTimeMillis() * 1_000_000L;
-        MetricRendering r = renderingCache.computeIfAbsent(metric.metricName(), this::computeRendering);
+        return map(System.currentTimeMillis() * 1_000_000L, metric, value);
+    }
 
+    public List<MetricData> mapAll(List<MetricRegistry.Sample> samples) {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        List<MetricData> result = new ArrayList<>(samples.size());
+        for (MetricRegistry.Sample s : samples) {
+            result.add(map(now, s.metric(), s.value()));
+        }
+        pruneCacheTo(samples);
+        return result;
+    }
+
+    private MetricData map(long now, KafkaMetric metric, double value) {
+        MetricRendering r = renderingCache.computeIfAbsent(metric.metricName(), this::computeRendering);
+        if (r.monotonic) {
+            return ImmutableMetricData.createDoubleSum(
+                    resource,
+                    ResourceFactory.SCOPE,
+                    r.name,
+                    metric.metricName().description(),
+                    "",
+                    ImmutableSumData.create(
+                            true,
+                            AggregationTemporality.CUMULATIVE,
+                            List.of(ImmutableDoublePointData.create(startEpochNanos, now, r.attributes, value))));
+        }
         return ImmutableMetricData.createDoubleGauge(
                 resource,
                 ResourceFactory.SCOPE,
@@ -66,23 +118,32 @@ public class MetricDataMapper {
                 ImmutableGaugeData.create(List.of(ImmutableDoublePointData.create(now, now, r.attributes, value))));
     }
 
-    public List<MetricData> mapAll(List<KafkaMetric> metrics) {
-        List<MetricData> result = new ArrayList<>(metrics.size());
-        for (KafkaMetric m : metrics) {
-            result.add(map(m));
+    /**
+     * Evict cached renderings for metrics no longer present in the live snapshot. Runs on
+     * the export thread after mapping, so a metric removal racing with an in-flight tick
+     * can't leave a permanently-stale entry (the next tick's snapshot won't contain it).
+     */
+    private void pruneCacheTo(List<MetricRegistry.Sample> samples) {
+        if (renderingCache.size() <= samples.size()) return;
+        Set<MetricName> live = new HashSet<>(samples.size() * 2);
+        for (MetricRegistry.Sample s : samples) {
+            live.add(s.metric().metricName());
         }
-        return result;
+        renderingCache.keySet().retainAll(live);
     }
 
-    /** Drop the cached rendering for a removed metric. Wired up by {@link MetricRegistry}. */
-    public void onMetricRemoved(MetricName name) {
-        renderingCache.remove(name);
+    /** Current rendering-cache entry count. Visible for tests verifying live-set pruning. */
+    int renderingCacheSize() {
+        return renderingCache.size();
     }
 
     private MetricRendering computeRendering(MetricName n) {
         String name = namespace.isEmpty()
                 ? MetricNameFormatter.format(n.group(), n.name())
                 : MetricNameFormatter.sanitize(namespace + "_" + n.group() + "_" + n.name());
-        return new MetricRendering(name, ResourceFactory.attributesOf(n.tags()));
+        // Kafka SPI cumulative counters are named "<something>-total" (e.g. record-send-total).
+        // Emit those as monotonic Sums so PromQL rate() is correct; everything else is a Gauge.
+        boolean monotonic = n.name().endsWith("-total");
+        return new MetricRendering(name, ResourceFactory.attributesOf(n.tags()), monotonic);
     }
 }

--- a/src/main/java/dev/monedula/metricsreporter/MetricRegistry.java
+++ b/src/main/java/dev/monedula/metricsreporter/MetricRegistry.java
@@ -5,7 +5,6 @@ package dev.monedula.metricsreporter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -14,20 +13,9 @@ public class MetricRegistry {
 
     private final AllowList allowList;
     private final ConcurrentHashMap<MetricName, KafkaMetric> metrics = new ConcurrentHashMap<>();
-    private volatile Consumer<MetricName> evictionListener;
 
     public MetricRegistry(List<Pattern> allowedPatterns) {
         this.allowList = new AllowList(allowedPatterns);
-    }
-
-    /**
-     * Register a listener notified when a metric leaves the registry. Used by
-     * {@link MetricDataMapper} to invalidate its per-metric rendering cache so
-     * removed metrics don't pile up indefinitely. Only one listener is kept;
-     * setting a new one replaces the previous binding.
-     */
-    public void setEvictionListener(Consumer<MetricName> listener) {
-        this.evictionListener = listener;
     }
 
     public void update(KafkaMetric metric) {
@@ -37,14 +25,21 @@ public class MetricRegistry {
     }
 
     public void remove(KafkaMetric metric) {
-        MetricName name = metric.metricName();
-        metrics.remove(name);
-        Consumer<MetricName> l = this.evictionListener;
-        if (l != null) l.accept(name);
+        metrics.remove(metric.metricName());
     }
 
-    public List<KafkaMetric> snapshot() {
-        List<KafkaMetric> result = new ArrayList<>();
+    /**
+     * A metric paired with the value observed for it at snapshot time. The value is read
+     * exactly once, here, so the export thread never re-reads {@link KafkaMetric#metricValue()}
+     * downstream — a second read could return a different (e.g. {@code NaN} for an empty
+     * rate window) or non-numeric value and, if the mapper threw on it, drop the whole batch.
+     * Reading once also halves the {@code synchronized} {@code metricValue()} calls per tick,
+     * lowering contention with Kafka's metric-recording threads.
+     */
+    public record Sample(KafkaMetric metric, double value) {}
+
+    public List<Sample> snapshot() {
+        List<Sample> result = new ArrayList<>();
         for (KafkaMetric m : metrics.values()) {
             Object raw = m.metricValue();
             // Kafka Measurable impls return double, but Gauge<T> can return Long/Integer/
@@ -52,7 +47,7 @@ public class MetricRegistry {
             if (!(raw instanceof Number)) continue;
             double v = ((Number) raw).doubleValue();
             if (Double.isFinite(v)) {
-                result.add(m);
+                result.add(new Sample(m, v));
             }
         }
         return result;

--- a/src/main/java/dev/monedula/metricsreporter/MetricRendering.java
+++ b/src/main/java/dev/monedula/metricsreporter/MetricRendering.java
@@ -16,9 +16,17 @@ public final class MetricRendering {
 
     public final String name;
     public final Attributes attributes;
+    /**
+     * Whether this metric is a monotonic cumulative counter (Kafka SPI {@code *-total}
+     * metrics) and should be emitted as an OTLP Sum rather than a Gauge, so PromQL
+     * {@code rate()} is semantically correct. Fixed for the metric's lifetime, so it
+     * lives in the cached rendering alongside the name and attributes.
+     */
+    public final boolean monotonic;
 
-    public MetricRendering(String name, Attributes attributes) {
+    public MetricRendering(String name, Attributes attributes, boolean monotonic) {
         this.name = name;
         this.attributes = attributes;
+        this.monotonic = monotonic;
     }
 }

--- a/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporter.java
+++ b/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporter.java
@@ -73,6 +73,15 @@ public class OtlpMetricReporter implements MetricsReporter {
      */
     private final String instanceId = UUID.randomUUID().toString();
 
+    /**
+     * Stable {@code startEpochNanos} for every cumulative counter this reporter emits
+     * (Kafka SPI {@code *-total} Sums and Yammer Counter/Timer/Histogram/Meter Sums).
+     * Captured once at construction and threaded into every (re)built mapper — including
+     * the {@link #contextChange} rebuild — so a mid-stream label change never looks like a
+     * counter reset to PromQL {@code rate()}.
+     */
+    private final long startEpochNanos = System.currentTimeMillis() * 1_000_000L;
+
     @Override
     public void contextChange(MetricsContext metricsContext) {
         try {
@@ -106,8 +115,7 @@ public class OtlpMetricReporter implements MetricsReporter {
             registry = new MetricRegistry(cfg.allowedMetrics());
 
             Map<String, String> resourceAttrs = combinedResourceAttributes();
-            MetricDataMapper mapper = new MetricDataMapper(namespace, resourceAttrs);
-            registry.setEvictionListener(mapper::onMetricRemoved);
+            MetricDataMapper mapper = new MetricDataMapper(namespace, resourceAttrs, startEpochNanos);
 
             collector = new MetricCollector(
                     registry, mapper, OtlpExporterFactory.create(cfg), cfg.intervalMs(), cfg.timeoutMs());
@@ -239,18 +247,13 @@ public class OtlpMetricReporter implements MetricsReporter {
         MetricCollector c = collector;
         if (c == null) return;
         Map<String, String> resourceAttrs = combinedResourceAttributes();
-        MetricDataMapper newMapper = new MetricDataMapper(namespace, resourceAttrs);
+        // Reuse the stable startEpochNanos so the rebuilt mappers' cumulative counters keep
+        // their original start time across the label change (no spurious PromQL reset). The
+        // old mapper instances become unreachable, so their caches GC out naturally.
+        MetricDataMapper newMapper = new MetricDataMapper(namespace, resourceAttrs, startEpochNanos);
         YammerMetricDataMapper newYammerMapper =
-                yammerRegistry != null ? new YammerMetricDataMapper(resourceAttrs) : null;
+                yammerRegistry != null ? new YammerMetricDataMapper(resourceAttrs, startEpochNanos) : null;
         c.replaceMappers(newMapper, newYammerMapper);
-        // Re-point the registries' eviction listeners at the new mappers' caches —
-        // the old mapper instances become unreachable so their caches GC out naturally.
-        if (registry != null) {
-            registry.setEvictionListener(newMapper::onMetricRemoved);
-        }
-        if (yammerRegistry != null && newYammerMapper != null) {
-            yammerRegistry.setEvictionListener(newYammerMapper::onMetricRemoved);
-        }
         JvmMetricsLifecycle jm = jvmMetrics;
         if (jm != null) {
             jm.rebuildIfRunning(resourceAttrs);
@@ -287,8 +290,7 @@ public class OtlpMetricReporter implements MetricsReporter {
             // metrics-core not on the classpath — shouldn't happen if KafkaYammerMetrics loaded
         }
 
-        YammerMetricDataMapper yammerMapper = new YammerMetricDataMapper(resourceAttrs);
-        yr.setEvictionListener(yammerMapper::onMetricRemoved);
+        YammerMetricDataMapper yammerMapper = new YammerMetricDataMapper(resourceAttrs, startEpochNanos);
         this.yammerRegistry = yr;
         collector.setYammer(yr, yammerMapper);
         log.info("OtlpMetricReporter attached to Kafka Yammer registry — broker-internal metrics enabled");

--- a/src/main/java/dev/monedula/metricsreporter/yammer/YammerMetricDataMapper.java
+++ b/src/main/java/dev/monedula/metricsreporter/yammer/YammerMetricDataMapper.java
@@ -25,8 +25,10 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class YammerMetricDataMapper {
@@ -56,16 +58,31 @@ public class YammerMetricDataMapper {
     private final ConcurrentHashMap<MetricName, String> nameCache = new ConcurrentHashMap<>();
 
     public YammerMetricDataMapper(Map<String, String> resourceAttributes) {
+        this(resourceAttributes, System.currentTimeMillis() * 1_000_000L);
+    }
+
+    public YammerMetricDataMapper(Map<String, String> resourceAttributes, long startEpochNanos) {
         this.resource = ResourceFactory.create(resourceAttributes);
-        this.startEpochNanos = System.currentTimeMillis() * 1_000_000L;
+        this.startEpochNanos = startEpochNanos;
+    }
+
+    /** Stable cumulative-counter start time; threaded into rebuilt mappers to avoid reset signals. */
+    public long startEpochNanos() {
+        return startEpochNanos;
     }
 
     public List<MetricData> mapAll(Collection<Map.Entry<MetricName, Metric>> snapshot) {
         long now = System.currentTimeMillis() * 1_000_000L;
         List<MetricData> result = new ArrayList<>(snapshot.size());
+        Set<MetricName> liveNames = new HashSet<>(snapshot.size() * 2);
+        Set<String> liveScopes = new HashSet<>();
         for (Map.Entry<MetricName, Metric> entry : snapshot) {
             MetricName n = entry.getKey();
             Metric m = entry.getValue();
+            liveNames.add(n);
+            if (n.getScope() != null && !n.getScope().isEmpty()) {
+                liveScopes.add(n.getScope());
+            }
             String name = nameCache.computeIfAbsent(n, YammerMetricDataMapper::formatName);
             Attributes baseAttrs = cachedAttributesForScope(n.getScope());
 
@@ -87,6 +104,13 @@ public class YammerMetricDataMapper {
             }
             // else: unknown metric type, skip
         }
+        // Prune caches to the live set on the export thread. nameCache is keyed per metric;
+        // scopeAttributesCache is keyed by the (shared) scope string, so it can only be
+        // evicted once no live metric references that scope — exactly what retainAll does
+        // against the scopes seen this tick. Keeps both caches bounded under topic churn
+        // without touching Kafka's metric-removal callback path.
+        nameCache.keySet().retainAll(liveNames);
+        scopeAttributesCache.keySet().retainAll(liveScopes);
         return result;
     }
 
@@ -135,12 +159,14 @@ public class YammerMetricDataMapper {
         }
     }
 
-    /** Drop the cached name for a removed metric. Wired up by {@link YammerMetricRegistry}. */
-    public void onMetricRemoved(MetricName name) {
-        nameCache.remove(name);
-        // scopeAttributesCache is keyed by scope string and shared across metrics with the
-        // same scope (e.g. all per-partition metrics on a topic share one entry), so it
-        // would be wrong to evict here on a single-metric removal.
+    /** Cached-name entry count. Visible for tests verifying live-set pruning. */
+    int nameCacheSize() {
+        return nameCache.size();
+    }
+
+    /** Cached-scope-attributes entry count. Visible for tests verifying live-set pruning. */
+    int scopeAttributesCacheSize() {
+        return scopeAttributesCache.size();
     }
 
     private static String formatName(MetricName n) {

--- a/src/main/java/dev/monedula/metricsreporter/yammer/YammerMetricRegistry.java
+++ b/src/main/java/dev/monedula/metricsreporter/yammer/YammerMetricRegistry.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 /**
@@ -27,19 +26,9 @@ public class YammerMetricRegistry implements MetricsRegistryListener {
     private final ConcurrentHashMap<MetricName, Metric> metrics = new ConcurrentHashMap<>();
     private final Set<MetricsRegistry> attached =
             java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<>());
-    private volatile Consumer<MetricName> evictionListener;
 
     public YammerMetricRegistry(List<Pattern> allowedPatterns) {
         this.allowList = new AllowList(allowedPatterns);
-    }
-
-    /**
-     * Register a listener notified when a metric leaves the registry. Used by
-     * {@link YammerMetricDataMapper} to invalidate its per-metric name cache.
-     * Only one listener is kept; setting a new one replaces the previous binding.
-     */
-    public void setEvictionListener(Consumer<MetricName> listener) {
-        this.evictionListener = listener;
     }
 
     /** Attach to a registry: capture currently-registered metrics + receive future events. */
@@ -77,8 +66,6 @@ public class YammerMetricRegistry implements MetricsRegistryListener {
     @Override
     public void onMetricRemoved(MetricName name) {
         metrics.remove(name);
-        Consumer<MetricName> l = this.evictionListener;
-        if (l != null) l.accept(name);
     }
 
     /** Snapshot of currently tracked (name, metric) pairs. */

--- a/src/test/java/dev/monedula/metricsreporter/MetricDataMapperTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/MetricDataMapperTest.java
@@ -5,6 +5,7 @@ package dev.monedula.metricsreporter;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import java.util.List;
@@ -101,10 +102,51 @@ class MetricDataMapperTest {
     @Test
     void maps_list_of_metrics() {
         var mapper = new MetricDataMapper(Map.of());
-        var metrics = List.of(
-                metric("producer-metrics", "record-send-rate", Map.of(), 1.0),
-                metric("producer-metrics", "record-error-rate", Map.of(), 2.0));
-        assertEquals(2, mapper.mapAll(metrics).size());
+        var samples = List.of(
+                new MetricRegistry.Sample(metric("producer-metrics", "record-send-rate", Map.of(), 1.0), 1.0),
+                new MetricRegistry.Sample(metric("producer-metrics", "record-error-rate", Map.of(), 2.0), 2.0));
+        assertEquals(2, mapper.mapAll(samples).size());
+    }
+
+    @Test
+    void total_suffixed_metric_maps_to_monotonic_cumulative_sum() {
+        var mapper = new MetricDataMapper(Map.of());
+        KafkaMetric m = metric("producer-metrics", "record-send-total", Map.of(), 42.0);
+        MetricData data = mapper.map(m);
+        assertEquals(MetricDataType.DOUBLE_SUM, data.getType());
+        assertTrue(data.getDoubleSumData().isMonotonic());
+        assertEquals(AggregationTemporality.CUMULATIVE, data.getDoubleSumData().getAggregationTemporality());
+        assertEquals(42.0, data.getDoubleSumData().getPoints().iterator().next().getValue(), 0.001);
+    }
+
+    @Test
+    void non_total_metric_stays_a_gauge() {
+        var mapper = new MetricDataMapper(Map.of());
+        KafkaMetric m = metric("producer-metrics", "record-send-rate", Map.of(), 1.0);
+        assertEquals(MetricDataType.DOUBLE_GAUGE, mapper.map(m).getType());
+    }
+
+    @Test
+    void cumulative_sum_uses_supplied_start_epoch() {
+        long startEpoch = 123_000_000_000L;
+        var mapper = new MetricDataMapper("", Map.of(), startEpoch);
+        KafkaMetric m = metric("producer-metrics", "record-send-total", Map.of(), 7.0);
+        MetricData data = mapper.map(m);
+        assertEquals(
+                startEpoch,
+                data.getDoubleSumData().getPoints().iterator().next().getStartEpochNanos());
+    }
+
+    @Test
+    void rendering_cache_is_pruned_to_the_live_snapshot() {
+        var mapper = new MetricDataMapper(Map.of());
+        KafkaMetric a = metric("producer-metrics", "record-send-rate", Map.of(), 1.0);
+        KafkaMetric b = metric("producer-metrics", "record-error-rate", Map.of(), 2.0);
+        // First tick sees both metrics.
+        mapper.mapAll(List.of(new MetricRegistry.Sample(a, 1.0), new MetricRegistry.Sample(b, 2.0)));
+        // Second tick: 'b' is gone. Its cached rendering must not linger.
+        mapper.mapAll(List.of(new MetricRegistry.Sample(a, 1.0)));
+        assertEquals(1, mapper.renderingCacheSize(), "stale rendering for removed metric was not pruned");
     }
 
     @Test

--- a/src/test/java/dev/monedula/metricsreporter/yammer/YammerMetricDataMapperTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/yammer/YammerMetricDataMapperTest.java
@@ -245,6 +245,39 @@ class YammerMetricDataMapperTest {
     }
 
     @Test
+    void caches_are_pruned_to_the_live_snapshot() {
+        // Two topic-scoped metrics on distinct topics populate both caches; when one topic's
+        // metric disappears from the snapshot, its name + scope entries must not linger
+        // (otherwise scopeAttributesCache leaks one entry per topic-partition forever).
+        MetricName a = new MetricName("kafka.server", "BrokerTopicMetrics", "BytesInPerSec", "topic.topic-a");
+        MetricName b = new MetricName("kafka.server", "BrokerTopicMetrics", "BytesInPerSec", "topic.topic-b");
+        Counter ca = registry.newCounter(a);
+        Counter cb = registry.newCounter(b);
+
+        mapper.mapAll(List.of(entry(a, ca), entry(b, cb)));
+        assertEquals(2, mapper.nameCacheSize());
+        assertEquals(2, mapper.scopeAttributesCacheSize());
+
+        // topic-b's metric is gone this tick.
+        mapper.mapAll(List.of(entry(a, ca)));
+        assertEquals(1, mapper.nameCacheSize(), "stale name-cache entry was not pruned");
+        assertEquals(1, mapper.scopeAttributesCacheSize(), "stale scope-cache entry was not pruned");
+    }
+
+    @Test
+    void cumulative_sum_uses_supplied_start_epoch() {
+        long startEpoch = 456_000_000_000L;
+        var fixed = new YammerMetricDataMapper(Map.of(), startEpoch);
+        MetricName mn = new MetricName("kafka.server", "ReplicaManager", "IsrShrinksPerSec");
+        Counter c = registry.newCounter(mn);
+        c.inc(3);
+        MetricData data = fixed.mapAll(List.of(entry(mn, c))).get(0);
+        assertEquals(
+                startEpoch,
+                data.getDoubleSumData().getPoints().iterator().next().getStartEpochNanos());
+    }
+
+    @Test
     void topic_scope_with_empty_partition_value_emits_topic_only() {
         MetricName mn = new MetricName("kafka.cluster", "Partition", "UnderReplicated", "topic.test-topic.partition.");
         Gauge<Integer> g = new Gauge<Integer>() {


### PR DESCRIPTION
Reworks the snapshot -> map export path shared by the Kafka SPI and Yammer sides. These changes interlock in the same hot-path classes, so they ship together:

- Capture each metric's value once, at snapshot time (MetricRegistry.Sample), instead of re-reading metricValue() in the mapper. A value that flips to NaN/non-numeric between the two reads previously threw and dropped the whole export batch; reading once also halves the synchronized metricValue() calls per tick.
- Export SPI "*-total" cumulative counters as monotonic OTLP Sums rather than gauges, so PromQL rate() is correct. Everything else stays a gauge. (This changes the emitted OTLP type for those series.)
- Prune the rendering/name/scope caches to the live snapshot on the export thread and drop the eviction-listener plumbing. Fixes an unbounded Yammer scope-cache leak under topic churn and a removal-vs-export race on the SPI rendering cache, and keeps all cache maintenance off Kafka's metric-callback path (callbacks now only put/remove from a map).
- Thread a stable startEpochNanos through mapper rebuilds so a contextChange label change does not read as a counter reset downstream.

## Summary

<!-- One or two sentences. What changes and why. -->

## Changes

<!-- Bullet list of what's new / different / removed. -->

## Testing

<!-- How did you verify this? Unit, integration, e2e, manual? -->

## Compatibility

- [ ] No public-API break (or break is intentional and documented below)
- [ ] Tested against the Kafka version matrix in CI (or N/A)
- [ ] Tested on JDK 17 and 21 via CI (or N/A)

## Related issues

<!-- Resolves #123 / Refs #456 -->
