### PR TITLE
Evaluate allow-list patterns independently to preserve backreferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow-list patterns are evaluated independently rather than folded into one
+  regex alternation, so a backreference in one pattern can no longer be corrupted
+  by capture-group renumbering across patterns.
+
 ### Added
 
 - Initial release of the OTLP-native Kafka `MetricsReporter` plugin

--- a/src/main/java/dev/monedula/metricsreporter/AllowList.java
+++ b/src/main/java/dev/monedula/metricsreporter/AllowList.java
@@ -4,40 +4,33 @@ package dev.monedula.metricsreporter;
 
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Allow-list of compiled regex patterns shared by the SPI and Yammer registries.
  * An empty pattern list means "allow all" — same semantics as the user-facing
  * {@code otlp.metric.reporter.allowed.metrics} configuration default.
  *
- * <p>Multiple patterns are combined into one anchored alternation at construction
- * so {@link #matches(String)} runs a single {@link java.util.regex.Matcher} pass
- * regardless of how many user patterns were configured — avoiding the per-call
- * {@code matcher()} allocation and N-deep iteration on Kafka's metric-callback
- * thread (a hot path called per metric add/change).
+ * <p>{@link #matches(String)} tests each user pattern with {@code Matcher.matches()}
+ * (whole-subject anchoring) and short-circuits on the first hit. Each pattern is kept
+ * and evaluated independently rather than folded into a single alternation: combining
+ * them renumbers each pattern's capture groups, which silently changes the meaning of
+ * any backreference (e.g. {@code (\w+)-\1}). This runs on the metric add/change
+ * callback — a per-registration path, not a per-measurement one — so iterating a
+ * handful of configured patterns is cheap and, unlike the alternation, always correct.
  */
 public final class AllowList {
 
-    private final Pattern combined;
+    private final List<Pattern> patterns;
 
     public AllowList(List<Pattern> patterns) {
-        if (patterns.isEmpty()) {
-            this.combined = null;
-        } else if (patterns.size() == 1) {
-            this.combined = patterns.get(0);
-        } else {
-            // Wrap each user pattern in a non-capturing group so its own anchors / flags
-            // can't bleed into the next alternative. matches() anchors the whole thing,
-            // preserving the per-pattern "must match entire subject" semantics.
-            String joined =
-                    patterns.stream().map(p -> "(?:" + p.pattern() + ")").collect(Collectors.joining("|"));
-            this.combined = Pattern.compile(joined);
-        }
+        this.patterns = List.copyOf(patterns);
     }
 
     public boolean matches(String subject) {
-        if (combined == null) return true;
-        return combined.matcher(subject).matches();
+        if (patterns.isEmpty()) return true;
+        for (Pattern p : patterns) {
+            if (p.matcher(subject).matches()) return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/dev/monedula/metricsreporter/AllowListTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/AllowListTest.java
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class AllowListTest {
+
+    private static List<Pattern> patterns(String... regexes) {
+        List<Pattern> ps = new java.util.ArrayList<>();
+        for (String r : regexes) ps.add(Pattern.compile(r));
+        return ps;
+    }
+
+    @Test
+    void empty_list_allows_everything() {
+        AllowList allowList = new AllowList(List.of());
+        assertTrue(allowList.matches("anything.at.all"));
+    }
+
+    @Test
+    void single_pattern_must_match_whole_subject() {
+        AllowList allowList = new AllowList(patterns("producer-metrics\\..*"));
+        assertTrue(allowList.matches("producer-metrics.record-send-rate"));
+        assertFalse(allowList.matches("xproducer-metrics.record-send-rate"));
+        assertFalse(allowList.matches("consumer-metrics.records-consumed-rate"));
+    }
+
+    @Test
+    void any_of_several_patterns_admits_the_subject() {
+        AllowList allowList = new AllowList(patterns("consumer.*", "producer.*"));
+        assertTrue(allowList.matches("producer-metrics.record-send-rate"));
+        assertTrue(allowList.matches("consumer-metrics.records-consumed-rate"));
+        assertFalse(allowList.matches("kafka.server.BytesInPerSec"));
+    }
+
+    @Test
+    void backreference_in_one_pattern_is_not_corrupted_by_another() {
+        // A backreference refers to a group by number. Folding multiple patterns into one
+        // alternation renumbers groups, so the second pattern's "\\1" would point at the
+        // first pattern's group instead of its own. Evaluating patterns independently keeps
+        // each backreference bound to its own capture group.
+        AllowList allowList = new AllowList(patterns("(\\w+)\\.first", "(\\w+)\\.\\1"));
+        // Second pattern means: "<word>.<same word>". "dup.dup" matches; "a.b" does not.
+        assertTrue(allowList.matches("dup.dup"));
+        assertFalse(allowList.matches("a.b"));
+        // First pattern still works independently.
+        assertTrue(allowList.matches("anything.first"));
+    }
+}


### PR DESCRIPTION
Folding multiple user patterns into a single anchored alternation renumbers each pattern's capture groups, which silently changes the meaning of any backreference (e.g. a "\1" in the second pattern would point at the first pattern's group). matches() now tests each pattern with Matcher.matches() and short-circuits on the first hit.

This runs on the metric add/change callback, a per-registration path rather than a per-measurement one, so iterating a handful of configured patterns is cheap and always correct.

## Summary

<!-- One or two sentences. What changes and why. -->

## Changes

<!-- Bullet list of what's new / different / removed. -->

## Testing

<!-- How did you verify this? Unit, integration, e2e, manual? -->

## Compatibility

- [ ] No public-API break (or break is intentional and documented below)
- [ ] Tested against the Kafka version matrix in CI (or N/A)
- [ ] Tested on JDK 17 and 21 via CI (or N/A)

## Related issues

<!-- Resolves #123 / Refs #456 -->
