### PR TITLE
Make the default OTLP endpoint transport-aware and fix path normaliza…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The default OTLP endpoint now follows the configured transport: gRPC defaults
+  to `http://localhost:4317`, HTTP to `http://localhost:4318` (previously HTTP
+  also defaulted to the gRPC :4317 port, producing an unreachable endpoint).
+
+### Fixed
+
+- The HTTP endpoint metrics-path normalization now preserves any query string or
+  fragment instead of clobbering it via string concatenation.
+
 ### Added
 
 - Initial release of the OTLP-native Kafka `MetricsReporter` plugin

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ All keys use the prefix `otlp.metric.reporter.`.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `otlp.metric.reporter.endpoint` | String | `http://localhost:4317` | OTLP collector endpoint. For `grpc`, use the collector gRPC endpoint such as `http://collector:4317`. For `http`, a bare collector root such as `http://collector:4318` is normalized to `http://collector:4318/v1/metrics`; custom paths are used as provided |
+| `otlp.metric.reporter.endpoint` | String | `http://localhost:4317` (grpc) / `http://localhost:4318` (http) | OTLP collector endpoint. The default follows `transport`: gRPC uses :4317, HTTP uses :4318. For `grpc`, use the collector gRPC endpoint such as `http://collector:4317`. For `http`, a bare collector root such as `http://collector:4318` is normalized to `http://collector:4318/v1/metrics`; custom paths are used as provided |
 | `otlp.metric.reporter.transport` | Enum | `grpc` | `grpc` or `http` |
 | `otlp.metric.reporter.interval.ms` | Long | `30000` | Export interval in milliseconds |
 | `otlp.metric.reporter.timeout.ms` | Long | `5000` | Per-export call timeout in milliseconds |

--- a/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporterConfig.java
+++ b/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporterConfig.java
@@ -16,7 +16,10 @@ public class OtlpMetricReporterConfig {
     // helpers. These are the canonical names of the keys Kafka passes via
     // AbstractConfig#originalsWithPrefix.
 
-    /** OTLP collector endpoint URL. Default: {@code http://localhost:4317}. */
+    /**
+     * OTLP collector endpoint URL. Default follows the transport:
+     * {@code http://localhost:4317} for gRPC, {@code http://localhost:4318} for HTTP.
+     */
     public static final String ENDPOINT = "otlp.metric.reporter.endpoint";
     /** OTLP transport. {@link #TRANSPORT_GRPC} or {@link #TRANSPORT_HTTP}. Default: {@code grpc}. */
     public static final String TRANSPORT = "otlp.metric.reporter.transport";
@@ -43,13 +46,19 @@ public class OtlpMetricReporterConfig {
 
     public static final String TRANSPORT_GRPC = "grpc";
     public static final String TRANSPORT_HTTP = "http";
+
+    /** Default collector endpoint for the gRPC transport (OTLP/gRPC standard port). */
+    public static final String DEFAULT_GRPC_ENDPOINT = "http://localhost:4317";
+    /** Default collector endpoint for the HTTP transport (OTLP/HTTP standard port). */
+    public static final String DEFAULT_HTTP_ENDPOINT = "http://localhost:4318";
+
     public static final String COMPRESSION_NONE = "none";
     public static final String COMPRESSION_GZIP = "gzip";
     private static final Set<String> SUPPORTED_TRANSPORTS = Set.of(TRANSPORT_GRPC, TRANSPORT_HTTP);
     private static final Set<String> SUPPORTED_COMPRESSION = Set.of(COMPRESSION_NONE, COMPRESSION_GZIP);
 
     private static final Map<String, String> DEFAULTS = Map.ofEntries(
-            Map.entry(ENDPOINT, "http://localhost:4317"),
+            Map.entry(ENDPOINT, DEFAULT_GRPC_ENDPOINT),
             Map.entry(TRANSPORT, TRANSPORT_GRPC),
             Map.entry(INTERVAL_MS, "30000"),
             Map.entry(TIMEOUT_MS, "5000"),
@@ -91,7 +100,11 @@ public class OtlpMetricReporterConfig {
 
     public OtlpMetricReporterConfig(Map<String, ?> configs) {
         this.transport = getString(configs, TRANSPORT, TRANSPORT_GRPC);
-        URI parsedEndpoint = parseEndpoint(getString(configs, ENDPOINT, "http://localhost:4317"));
+        // Default endpoint follows the chosen transport: OTLP/gRPC is :4317, OTLP/HTTP is :4318.
+        // Using the gRPC port for an http transport (the old single default) silently produced
+        // an unreachable endpoint whenever http was selected without an explicit endpoint.
+        String defaultEndpoint = TRANSPORT_HTTP.equals(this.transport) ? DEFAULT_HTTP_ENDPOINT : DEFAULT_GRPC_ENDPOINT;
+        URI parsedEndpoint = parseEndpoint(getString(configs, ENDPOINT, defaultEndpoint));
         this.endpoint = normalizeEndpoint(parsedEndpoint, this.transport);
         this.intervalMs = getLong(configs, INTERVAL_MS, 30_000L);
         this.timeoutMs = getLong(configs, TIMEOUT_MS, 5_000L);
@@ -143,13 +156,24 @@ public class OtlpMetricReporterConfig {
     }
 
     private static String normalizeEndpoint(URI parsed, String transport) {
-        String raw = parsed.toString();
-        if (!TRANSPORT_HTTP.equals(transport)) return raw;
+        if (!TRANSPORT_HTTP.equals(transport)) return parsed.toString();
         String path = parsed.getPath();
-        if (path == null || path.isBlank() || "/".equals(path)) {
-            return raw.replaceAll("/+$", "") + "/v1/metrics";
+        boolean bare = path == null || path.isBlank() || path.chars().allMatch(c -> c == '/');
+        if (!bare) return parsed.toString(); // caller supplied an explicit signal path; leave it.
+        // Append the OTLP/HTTP metrics path by rebuilding from components, so any query string
+        // or fragment is preserved in place rather than being clobbered by string concatenation
+        // (e.g. "http://host:4318?k=v" must become "http://host:4318/v1/metrics?k=v").
+        try {
+            return new URI(
+                            parsed.getScheme(),
+                            parsed.getAuthority(),
+                            "/v1/metrics",
+                            parsed.getQuery(),
+                            parsed.getFragment())
+                    .toString();
+        } catch (URISyntaxException e) {
+            throw new ConfigException(ENDPOINT, parsed.toString(), "could not normalize endpoint: " + e.getMessage());
         }
-        return raw;
     }
 
     private static List<Pattern> compilePatterns(Map<String, ?> cfg) {

--- a/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterConfigTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterConfigTest.java
@@ -129,6 +129,36 @@ class OtlpMetricReporterConfigTest {
     }
 
     @Test
+    void http_transport_without_explicit_endpoint_defaults_to_http_port() {
+        // Selecting http transport without an endpoint must not fall back to the gRPC :4317
+        // port (which would be unreachable for OTLP/HTTP). It should default to :4318.
+        var cfg = new OtlpMetricReporterConfig(Map.of("otlp.metric.reporter.transport", "http"));
+        assertEquals("http://localhost:4318/v1/metrics", cfg.endpoint());
+    }
+
+    @Test
+    void grpc_transport_without_explicit_endpoint_defaults_to_grpc_port() {
+        var cfg = new OtlpMetricReporterConfig(Map.of("otlp.metric.reporter.transport", "grpc"));
+        assertEquals("http://localhost:4317", cfg.endpoint());
+    }
+
+    @Test
+    void http_transport_preserves_query_string_when_appending_metrics_path() {
+        var cfg = new OtlpMetricReporterConfig(Map.of(
+                "otlp.metric.reporter.endpoint", "http://collector:4318?tenant=monedula",
+                "otlp.metric.reporter.transport", "http"));
+        assertEquals("http://collector:4318/v1/metrics?tenant=monedula", cfg.endpoint());
+    }
+
+    @Test
+    void http_transport_strips_trailing_slash_before_appending_metrics_path() {
+        var cfg = new OtlpMetricReporterConfig(Map.of(
+                "otlp.metric.reporter.endpoint", "http://collector:4318/",
+                "otlp.metric.reporter.transport", "http"));
+        assertEquals("http://collector:4318/v1/metrics", cfg.endpoint());
+    }
+
+    @Test
     void throws_on_invalid_regex_pattern() {
         assertThrows(
                 ConfigException.class,


### PR DESCRIPTION
…tion

Selecting transport=http without an explicit endpoint previously fell back to the gRPC default http://localhost:4317, an unreachable port for OTLP/HTTP. The default endpoint now follows the transport: gRPC -> :4317, HTTP -> :4318.

Also rebuild the HTTP metrics-path endpoint from URI components instead of string concatenation, so a query string or fragment is preserved in place (e.g. http://host:4318?k=v -> http://host:4318/v1/metrics?k=v) rather than being clobbered.

## Summary

<!-- One or two sentences. What changes and why. -->

## Changes

<!-- Bullet list of what's new / different / removed. -->

## Testing

<!-- How did you verify this? Unit, integration, e2e, manual? -->

## Compatibility

- [ ] No public-API break (or break is intentional and documented below)
- [ ] Tested against the Kafka version matrix in CI (or N/A)
- [ ] Tested on JDK 17 and 21 via CI (or N/A)

## Related issues

<!-- Resolves #123 / Refs #456 -->
