### PR TITLE
Keep metric export alive when a tick throws an Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Export no longer stops permanently if a tick throws an `Error` (e.g. a
+  first-tick `NoClassDefFoundError`): the scheduled task now catches `Throwable`,
+  logs, and retries on the next interval instead of being silently cancelled by
+  `scheduleAtFixedRate`.
+
 ### Added
 
 - Initial release of the OTLP-native Kafka `MetricsReporter` plugin

--- a/src/main/java/dev/monedula/metricsreporter/MetricCollector.java
+++ b/src/main/java/dev/monedula/metricsreporter/MetricCollector.java
@@ -100,6 +100,11 @@ public class MetricCollector {
             scheduler.shutdownNow();
             Thread.currentThread().interrupt();
         }
+        // If awaitTermination timed out, shutdownNow() has interrupted an in-flight tick that may
+        // still be inside exporter.export() as we call exporter.shutdown() below. The OTLP exporter
+        // tolerates this concurrent call; the worst case is a benign "did not complete cleanly"
+        // warn-log. We accept that over adding more teardown latency on the Kafka close() thread —
+        // bounded shutdown keeps broker shutdown responsive (Kafka availability first).
         var shutdownResult = exporter.shutdown().join(timeoutMs, TimeUnit.MILLISECONDS);
         if (!shutdownResult.isSuccess()) {
             log.warn(
@@ -163,7 +168,12 @@ public class MetricCollector {
             if (!success) {
                 log.warn("OTLP metric export failed or timed out — dropping this batch");
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            // Catch Throwable, not just Exception: scheduleAtFixedRate silently cancels all
+            // future executions if the task throws, and the captured throwable never reaches
+            // the thread's uncaughtExceptionHandler — so an Error here (e.g. a first-tick
+            // NoClassDefFoundError from lazily-loaded shaded classes) would stop export
+            // permanently with no log. Fail open: log, count a failure, retry next tick.
             log.warn("Error during metric export tick — skipping batch", e);
             success = false;
         } finally {

--- a/src/test/java/dev/monedula/metricsreporter/MetricCollectorTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/MetricCollectorTest.java
@@ -75,6 +75,31 @@ class MetricCollectorTest {
     }
 
     @Test
+    void error_thrown_during_export_does_not_kill_the_scheduler() throws InterruptedException {
+        // A Throwable that isn't an Exception (e.g. a lazily-triggered NoClassDefFoundError on
+        // the first export, or an AssertionError) must not cancel the fixed-rate schedule.
+        // scheduleAtFixedRate silently suppresses all future runs if a task throws, so the
+        // export thread would go dark with no log — violating the fail-open assumption.
+        CountDownLatch latch = new CountDownLatch(3);
+        MetricExporter exporter = Mockito.mock(MetricExporter.class);
+        when(exporter.export(any())).thenAnswer(inv -> {
+            latch.countDown();
+            throw new AssertionError("boom"); // an Error, not an Exception
+        });
+        when(exporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+        MetricCollector collector =
+                new MetricCollector(new MetricRegistry(List.of()), new MetricDataMapper(Map.of()), exporter, 50L, 500L);
+        collector.start();
+        assertTrue(
+                latch.await(3, TimeUnit.SECONDS), "scheduler stopped after an Error in a tick; export was not retried");
+        collector.stop();
+        assertTrue(
+                collector.exportFailureCount() >= 3,
+                "failure count was " + collector.exportFailureCount() + ", expected >= 3");
+    }
+
+    @Test
     void empty_registry_still_exports_self_monitoring_metrics() throws InterruptedException {
         // Previously this test asserted no export when the registry was empty.
         // Self-monitoring metrics are emitted on every tick now (so operators see


### PR DESCRIPTION
scheduleAtFixedRate silently cancels all future executions if the task throws, and the captured throwable never reaches the thread's uncaughtExceptionHandler. An Error in an export tick (for example a first-tick NoClassDefFoundError from lazily-loaded shaded classes) would stop export permanently with no log, violating the fail-open assumption.

Catch Throwable (not just Exception) in exportTick: log, count a failure, retry next tick. Also document the benign shutdownNow/exporter-shutdown race in stop().

## Summary

<!-- One or two sentences. What changes and why. -->

## Changes

<!-- Bullet list of what's new / different / removed. -->

## Testing

<!-- How did you verify this? Unit, integration, e2e, manual? -->

## Compatibility

- [ ] No public-API break (or break is intentional and documented below)
- [ ] Tested against the Kafka version matrix in CI (or N/A)
- [ ] Tested on JDK 17 and 21 via CI (or N/A)

## Related issues

<!-- Resolves #123 / Refs #456 -->
