### PR TITLE
Add KIP-714 client telemetry forwarding and client dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- KIP-714 client telemetry forwarding: the reporter now implements Kafka's
+  `ClientTelemetry` interface, receives the OTLP metrics that KIP-714 clients
+  push to the broker, and forwards them to the collector as a third metric
+  stream alongside the SPI and Yammer registries. Forwarded client metrics are
+  enriched with broker identity (`kafka_cluster_id`/`kafka_node_id`) and
+  `client_id` by default; `client_instance_id`, principal, and client address
+  are opt-in. New config keys under `otlp.metric.reporter.client.telemetry.*`,
+  five `monedula_reporter_clienttelemetry_*` self-monitoring metrics, two
+  Grafana client dashboards (producer/consumer, split into Standard vs
+  Extended panels by client-library portability), and quickstart demo clients
+  (Java by default, librdkafka/confluent-kafka-python behind a compose
+  profile).
 
 ### Changed
 
@@ -19,6 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Metric rename:** the export-duration self-metric now reaches Prometheus as
+  `monedula_reporter_export_duration_ms` — the name the README and the
+  quickstart dashboards/alerts always documented. In 0.9.0 the metric carried a
+  redundant OTLP `ms` unit that made the collector's Prometheus exporter append
+  a unit suffix, so it was actually scraped as
+  `monedula_reporter_export_duration_ms_milliseconds`. Any dashboard, recording
+  rule, or alert built against that suffixed name must be updated to the
+  documented name after upgrading.
 - The HTTP endpoint metrics-path normalization now preserves any query string or
   fragment instead of clobbering it via string concatenation.
 - Export no longer stops permanently if a tick throws an `Error` (e.g. a

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ All keys use the prefix `otlp.metric.reporter.`.
 | `otlp.metric.reporter.client.certificate.path` | String | `""` | Optional path to a PEM client certificate for mTLS. Must be configured together with `otlp.metric.reporter.client.key.path` |
 | `otlp.metric.reporter.client.key.path` | String | `""` | Optional path to a PEM client private key for mTLS. Must be configured together with `otlp.metric.reporter.client.certificate.path` |
 | `otlp.metric.reporter.jvm.metrics.enabled` | Boolean | `true` | Whether to also export JVM runtime metrics via OpenTelemetry's runtime instrumentation library. Disable if you scrape JVM metrics elsewhere. |
+| `otlp.metric.reporter.client.telemetry.enabled` | Boolean | `true` | Enable the KIP-714 client-telemetry receiver. Auto-active on brokers but inert until a client-metrics subscription exists (see below); `false` makes the broker not advertise the capability at all |
+| `otlp.metric.reporter.client.telemetry.enrich.broker` | Boolean | `true` | Attach broker identity (`kafka_cluster_id` / `kafka_node_id`) to forwarded client metrics so they join broker series in PromQL |
+| `otlp.metric.reporter.client.telemetry.enrich.client.identity` | Boolean | `false` | Also attach the authenticated principal (`kafka_client_principal`) and client address (`kafka_client_address`). High-cardinality / PII — opt in deliberately |
+| `otlp.metric.reporter.client.telemetry.enrich.client.id` | Boolean | `true` | Attach the client's `client_id` (from the request context) as a label, so client metrics can be grouped per application. Moderate cardinality; on by default |
+| `otlp.metric.reporter.client.telemetry.enrich.client.instance.id` | Boolean | `false` | Attach the KIP-714 `client_instance_id` (a per-client-instance UUID) as a label. High cardinality — opt in deliberately |
+| `otlp.metric.reporter.client.telemetry.queue.capacity` | Int | `1024` | Bounded in-memory queue for inbound client pushes; overflow drops the payload (counted in `monedula_reporter_clienttelemetry_dropped_total`) |
 
 For TLS with the platform default trust store, use an `https://` OTLP endpoint. Configure `trusted.certificates.path` when the collector uses a private CA, and configure both client TLS paths when the collector requires mutual TLS. If any of these static settings are malformed or unreadable, the reporter logs the startup failure and runs as no-op so Kafka remains available.
 
@@ -190,6 +196,33 @@ For TLS with the platform default trust store, use an `https://` OTLP endpoint. 
 Anything beyond the reporter-level controls above — credential rotation, HTTP/SOCKS proxy chains, fan-out to multiple backends, vendor-specific OTLP exporters (Grafana Cloud, Honeycomb, Datadog, …), batching/retry policy — lives in the OpenTelemetry Collector, not in this plugin. See the upstream [Collector configuration docs](https://opentelemetry.io/docs/collector/configuration/) for those operational concerns. The reporter's settings rotate via JVM restart only (see [docs/assumptions.md](docs/assumptions.md#operational-assumptions)).
 
 Metric names are emitted as flat lowercase `{namespace}_{group}_{name}` (Strimzi-style): non-alphanumeric characters become underscores, consecutive underscores collapse, and leading/trailing underscores are stripped. The `{namespace}` segment is sourced from `MetricsContext._namespace` (e.g. `kafka.server` on a broker, `kafka.producer` / `kafka.consumer` on clients). Example: broker-side `producer-metrics` / `record-send-rate` becomes `kafka_server_producer_metrics_record_send_rate`. If no namespace is present in the context, the prefix is omitted (`producer_metrics_record_send_rate`).
+
+## Client telemetry (KIP-714)
+
+Beyond the broker's SPI and Yammer registries, the plugin also receives **client-pushed** metrics via [KIP-714](https://cwiki.apache.org/confluence/display/KAFKA/KIP-714%3A+Client+metrics+and+observability). `OtlpMetricReporter` implements Kafka's `ClientTelemetry` interface, so remote producers and consumers can push their *own* OTLP telemetry (client-side request latencies, rebalance/coordinator timings, connection churn) to the broker — and this plugin forwards it to the same collector, with no instrumentation on the client applications. It is a third metric stream alongside the broker SPI and Yammer registries.
+
+The receiver is **auto-enabled on brokers but inert until you configure a client-metrics subscription** (`kafka-client-metrics.sh` or a `CLIENT_METRICS` dynamic config). With no subscription, KIP-714 clients complete the handshake but never push, so nothing flows. Set `otlp.metric.reporter.client.telemetry.enabled=false` to refuse the capability entirely (the broker then won't advertise it).
+
+Forwarded client metrics are enriched, by default, with the same `kafka_cluster_id` / `kafka_node_id` resource labels the broker's own series carry, so client and broker series join cleanly in PromQL. The client's `client_id` is also added by default (`client.telemetry.enrich.client.id`), giving a per-application label so metrics from different clients don't merge. The KIP-714 `client_instance_id` (a per-instance UUID, high cardinality) is opt-in via `client.telemetry.enrich.client.instance.id=true`, and the authenticated principal + client address are opt-in via `client.telemetry.enrich.client.identity=true` (PII).
+
+> KIP-714 also defines `client_software_name` / `client_software_version` labels, but Kafka does not expose those to the telemetry-receiver plugin (the broker learns them from the client's `ApiVersions` request but doesn't pass them on), so the plugin cannot add them. The client's instrumentation scope (`otel_scope_name` / `otel_scope_version`) is the closest available signal — e.g. librdkafka reports its client id and version there, while the Java client reports a generic `kafka-client` scope.
+
+Notes and limits:
+
+- **`allowed.metrics` does not apply to client metrics.** Which client metrics are collected is governed by the KIP-714 subscription itself (broker-side), so a second filter here would be redundant.
+- **Fidelity boundary.** Gauge, sum, and histogram data points are forwarded; any other OTLP type (exponential histogram, summary) is dropped and counted in `monedula_reporter_clienttelemetry_unsupported_metrics_dropped_total`. This covers the standard KIP-714 client metric set.
+- **One receiver per broker.** Kafka uses a single `ClientTelemetry` reporter; if another telemetry plugin is also configured, which one Kafka selects is undefined.
+- **Broker identity is attached once the broker context is known.** Client metrics forwarded before Kafka delivers the broker `MetricsContext` carry no `kafka_cluster_id` / `kafka_node_id` labels. In practice this window closes at broker startup, long before any operator configures a subscription, so client pushes are always enriched — this mirrors how the SPI/Yammer series acquire their context labels.
+
+The receiver path is fail-safe like the rest of the plugin: client pushes are copied onto a bounded in-memory queue on the request-handler thread (never blocking Kafka) and forwarded asynchronously; collector failures drop the batch and never stall the broker. Five self-monitoring metrics describe its health on every export tick:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `monedula_reporter_clienttelemetry_received_total` | counter | Client telemetry payloads accepted (per push). |
+| `monedula_reporter_clienttelemetry_forwarded_total` | counter | Payloads successfully forwarded to the collector. |
+| `monedula_reporter_clienttelemetry_dropped_total` | counter | Payloads dropped (queue full or export failure). |
+| `monedula_reporter_clienttelemetry_unsupported_metrics_dropped_total` | counter | Individual data points dropped as unsupported types. |
+| `monedula_reporter_clienttelemetry_queue_depth` | gauge | Current depth of the inbound queue. |
 
 ## Quickstart
 
@@ -207,7 +240,7 @@ Give the containers ~45 seconds to come up. The compose file mounts the freshly-
 
 ### Open Grafana
 
-Visit [http://localhost:3000](http://localhost:3000) (anonymous access enabled — no login). Five dashboards are auto-provisioned into the **Kafka** folder:
+Visit [http://localhost:3000](http://localhost:3000) (anonymous access enabled — no login). Seven dashboards are auto-provisioned into the **Kafka** folder:
 
 | Dashboard | UID | Use it for |
 |-----------|-----|------------|
@@ -216,6 +249,8 @@ Visit [http://localhost:3000](http://localhost:3000) (anonymous access enabled �
 | Kafka Consumption | [`kafka-otlp-consumption`](http://localhost:3000/d/kafka-otlp-consumption) | Consumer-side: outbound throughput, Fetch latency, replica-fetcher lag |
 | Kafka Topic Details | [`kafka-otlp-topic-details`](http://localhost:3000/d/kafka-otlp-topic-details) | Per-topic drill-down: throughput, per-partition log end offset, leaders, ISR |
 | Kafka JVM Health | [`kafka-otlp-jvm`](http://localhost:3000/d/kafka-otlp-jvm) | JVM runtime: heap, GC, threads, class loading, CPU |
+| Kafka Producers (client) | [`kafka-otlp-client-producers`](http://localhost:3000/d/kafka-otlp-client-producers) | KIP-714 client-push: producer throughput, record error rate, batch metrics |
+| Kafka Consumers (client) | [`kafka-otlp-client-consumers`](http://localhost:3000/d/kafka-otlp-client-consumers) | KIP-714 client-push: fetch throughput, commit rate, assignment churn |
 
 ### Start at the overview
 
@@ -256,6 +291,44 @@ The plugin also exports JVM runtime metrics via OpenTelemetry's `opentelemetry-r
 ### Drop down to Prometheus
 
 Prometheus is live on [http://localhost:9090](http://localhost:9090) if you want to write ad-hoc PromQL or confirm metric-type metadata flows end-to-end (e.g. `curl localhost:9090/api/v1/metadata?metric=kafka_controller_kafkacontroller_activecontrollercount` should report `"type":"gauge"`, not `"unknown"`).
+
+### Client telemetry is enabled automatically
+
+The `demo` service creates a KIP-714 client-metrics subscription (`quickstart-clients`,
+all metrics, 5s interval) and runs a continuous producer + consumer against the
+`quickstart-demo` topic. Those clients push their own OTLP telemetry to the brokers,
+which the plugin forwards to the collector — populating the **Kafka Producers (client)**
+and **Kafka Consumers (client)** dashboards (in the `Kafka` folder), and feeding the
+broker-side dashboards too.
+
+To turn it off, remove the `demo` service from `docker-compose.yml`, or delete the
+subscription:
+
+    docker exec quickstart-kafka1-1 /opt/kafka/bin/kafka-client-metrics.sh \
+      --bootstrap-server kafka1:9092 --delete --name quickstart-clients
+
+On your own cluster, create a subscription the same way (`--alter --name <n>
+--metrics "*" --interval 5000`); any KIP-714 client (`enable.metrics.push=true`,
+the default) will then push.
+
+### Standard vs Extended panels (client-library portability)
+
+KIP-714 standardizes a small core set of metric names that **every** compliant client emits; beyond that, each client library exposes its own extended metrics. The Java/JVM client pushes its full internal registry (~100+ series); librdkafka-based clients (confluent-kafka for Python / Go / .NET / Node, librdkafka ≥ 2.5) emit **only the standard set**. So the client dashboards split their panels into two rows:
+
+- **Standard — populated by all KIP-714 clients:** request / fetch / rebalance / commit / per-node latency, produce throttle, record-queue time, poll-idle ratio, assigned partitions, connection creation.
+- **Extended — JVM/Java client only:** throughput rates, consumer lag/lead, batching & buffer, per-topic and per-member breakdowns, etc. These panels are **empty for librdkafka-based clients**.
+
+Because the plugin adds a `client_id` label (see `enrich.client.id` above), metrics from different clients **don't** merge — so you can run a librdkafka client (a confluent-kafka-python producer/consumer, behind a Compose profile) **alongside** the Java demo and compare them on the same dashboards:
+
+```bash
+docker compose --project-directory quickstart --profile librdkafka up -d demo-librdkafka
+```
+
+Then use the **Client** dropdown at the top of the client dashboards to filter by `client_id`:
+- pick the librdkafka client → the **Standard** panels are populated, the **Extended** panels are empty (it only emits the standard set);
+- pick the Java client (`perf-producer-client` / `console-consumer`) → everything is populated.
+
+The profile is self-contained: an init step (re)creates the `quickstart-clients` subscription, so it works regardless of whether the Java `demo` is running. (The brokers don't persist cluster metadata, so the subscription can vanish after a broker recreate — the init step puts it back. Allow ~1 minute after start for the client to fetch the subscription before its metrics appear.) Stop it with `docker compose --project-directory quickstart stop demo-librdkafka`.
 
 ### Stop the stack
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${otelVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp:${otelVersion}"
     implementation "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java17:${otelInstrumentationVersion}"
+    implementation "io.opentelemetry.proto:opentelemetry-proto:${otelProtoVersion}"
 
     testImplementation "org.apache.kafka:kafka-clients:${kafkaVersion}"
     testImplementation "com.yammer.metrics:metrics-core:${yammerMetricsVersion}"
@@ -116,6 +117,7 @@ shadowJar {
     relocate 'io.grpc', 'dev.monedula.metricsreporter.shaded.grpc'
     relocate 'okhttp3', 'dev.monedula.metricsreporter.shaded.okhttp3'
     relocate 'okio', 'dev.monedula.metricsreporter.shaded.okio'
+    relocate 'com.google.protobuf', 'dev.monedula.metricsreporter.shaded.protobuf'
     relocate 'kotlin', 'dev.monedula.metricsreporter.shaded.kotlin'
     relocate 'org.jetbrains.annotations', 'dev.monedula.metricsreporter.shaded.jetbrains_annotations'
     relocate 'org.intellij.lang.annotations', 'dev.monedula.metricsreporter.shaded.intellij_annotations'

--- a/e2e/src/test/java/dev/monedula/metricsreporter/e2e/KafkaOtlpE2ETest.java
+++ b/e2e/src/test/java/dev/monedula/metricsreporter/e2e/KafkaOtlpE2ETest.java
@@ -11,11 +11,22 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
@@ -46,106 +57,123 @@ class KafkaOtlpE2ETest {
     /**
      * Fixed host port for Kafka's external listener. Using a fixed port avoids
      * the chicken-and-egg problem of needing to know the mapped port before
-     * setting ADVERTISED_LISTENERS in the container environment.
+     * setting ADVERTISED_LISTENERS in the container environment. Shared by both
+     * tests — safe because JUnit runs the methods of this class sequentially;
+     * enabling parallel execution would require distinct ports per test.
      */
     private static final int KAFKA_HOST_PORT = 49092;
+
+    /** The three-container observability stack shared by both tests. */
+    private record E2eStack(GenericContainer<?> collector, GenericContainer<?> prometheus, GenericContainer<?> kafka) {
+
+        String prometheusUrl() {
+            return "http://" + prometheus.getHost() + ":" + prometheus.getMappedPort(9090);
+        }
+
+        /** OTLP gRPC endpoint reachable from the test JVM (mapped host port). */
+        String collectorGrpcEndpointFromHost() {
+            return "http://" + collector.getHost() + ":" + collector.getMappedPort(4317);
+        }
+
+        void stopAll() {
+            if (kafka != null) kafka.stop();
+            if (prometheus != null) prometheus.stop();
+            if (collector != null) collector.stop();
+        }
+    }
+
+    /**
+     * Start the collector → Prometheus → Kafka(KRaft + plugin) stack on {@code network}.
+     * The container configuration is deliberately identical for every test in this class —
+     * keep changes here so the tests can't drift apart; {@code logSuffix} only disambiguates
+     * the per-test log-consumer names. Containers that already started are stopped again if
+     * a later one fails to start.
+     *
+     * <p>Collector first, because Prometheus scrapes its /metrics endpoint (port 8889) via the
+     * "otel-collector" network alias — that alias must exist before Prometheus's first scrape.
+     * Exposed: 4317 (OTLP gRPC receiver), 8889 (Prometheus pull endpoint). The pull-based path
+     * preserves # TYPE / # HELP, so /api/v1/metadata returns real types rather than "unknown".
+     *
+     * <p>Kafka: KafkaContainer from testcontainers only supports Confluent images, so we use
+     * GenericContainer with apache/kafka in KRaft mode. Two listeners: PLAINTEXT (9092) for
+     * internal Docker network traffic, EXTERNAL (19092) bound to {@link #KAFKA_HOST_PORT} so the
+     * test JVM can connect. The broker carries the OTLP plugin (stable-name JAR produced by the
+     * quickstartShadowJar task, avoiding a hard-coded version). timeout.ms is set below the 5s
+     * interval because OtlpMetricReporterConfig requires timeout.ms < interval.ms strictly.
+     */
+    private static E2eStack startStack(Network network, String logSuffix) {
+        GenericContainer<?> collector = null;
+        GenericContainer<?> prometheus = null;
+        GenericContainer<?> kafka = null;
+        try {
+            collector = new GenericContainer<>("otel/opentelemetry-collector-contrib:0.152.0")
+                    .withNetwork(network)
+                    .withNetworkAliases("otel-collector")
+                    .withCopyFileToContainer(
+                            MountableFile.forClasspathResource("otel-collector-e2e-config.yaml"),
+                            "/etc/otel-collector-config.yaml")
+                    .withCommand("--config=/etc/otel-collector-config.yaml")
+                    .withExposedPorts(4317, 8889)
+                    .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("otel-collector" + logSuffix)))
+                    .waitingFor(Wait.forLogMessage(".*Everything is ready.*", 1));
+            collector.start();
+
+            prometheus = new GenericContainer<>("prom/prometheus:v3.11.3")
+                    .withNetwork(network)
+                    .withNetworkAliases("prometheus")
+                    .withCopyFileToContainer(
+                            MountableFile.forClasspathResource("prometheus-e2e.yml"), "/etc/prometheus/prometheus.yml")
+                    .withCommand("--config.file=/etc/prometheus/prometheus.yml")
+                    .withExposedPorts(9090)
+                    .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("prometheus" + logSuffix)))
+                    .waitingFor(Wait.forHttp("/-/ready").forPort(9090));
+            prometheus.start();
+
+            kafka = new GenericContainer<>("apache/kafka:4.2.0")
+                    .withNetwork(network)
+                    .withNetworkAliases("kafka")
+                    .withEnv("KAFKA_NODE_ID", "1")
+                    .withEnv("KAFKA_PROCESS_ROLES", "broker,controller")
+                    .withEnv(
+                            "KAFKA_LISTENERS",
+                            "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:19092")
+                    .withEnv(
+                            "KAFKA_ADVERTISED_LISTENERS",
+                            "PLAINTEXT://kafka:9092,EXTERNAL://localhost:" + KAFKA_HOST_PORT)
+                    .withEnv(
+                            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                            "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT")
+                    .withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@kafka:9093")
+                    .withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+                    .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
+                    // Plugin in the broker: exports broker-side metrics (SPI + Yammer) and receives
+                    // KIP-714 client pushes, all forwarded to the collector over OTLP.
+                    .withEnv("KAFKA_METRIC_REPORTERS", "dev.monedula.metricsreporter.OtlpMetricReporter")
+                    .withEnv("KAFKA_OTLP_METRIC_REPORTER_ENDPOINT", "http://otel-collector:4317")
+                    .withEnv("KAFKA_OTLP_METRIC_REPORTER_TRANSPORT", "grpc")
+                    .withEnv("KAFKA_OTLP_METRIC_REPORTER_INTERVAL_MS", "5000")
+                    .withEnv("KAFKA_OTLP_METRIC_REPORTER_TIMEOUT_MS", "3000")
+                    .withCopyFileToContainer(
+                            MountableFile.forHostPath("../build/quickstart-libs/monedula-metrics-reporter.jar"),
+                            "/opt/kafka/libs/monedula-metrics-reporter.jar")
+                    .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka" + logSuffix)))
+                    .waitingFor(Wait.forLogMessage(".*Kafka Server started.*", 1));
+            kafka.setPortBindings(List.of(KAFKA_HOST_PORT + ":19092"));
+            kafka.start();
+
+            return new E2eStack(collector, prometheus, kafka);
+        } catch (RuntimeException e) {
+            new E2eStack(collector, prometheus, kafka).stopAll();
+            throw e;
+        }
+    }
 
     @Test
     void kafka_producer_metrics_appear_in_prometheus() throws Exception {
         try (Network network = Network.newNetwork()) {
-            GenericContainer<?> prometheus = null;
-            GenericContainer<?> collector = null;
-            GenericContainer<?> kafka = null;
+            E2eStack stack = startStack(network, "");
             try {
-                // --- OTLP Collector ---
-                // Start the collector first because Prometheus scrapes its
-                // /metrics endpoint (port 8889) via the "otel-collector"
-                // network alias — that alias must exist before Prometheus
-                // starts its first scrape attempt.
-                //
-                // We expose:
-                //   4317 - OTLP gRPC receiver (Kafka broker + test JVM push to it)
-                //   8889 - Prometheus /metrics endpoint (pull-based pipeline)
-                collector = new GenericContainer<>("otel/opentelemetry-collector-contrib:0.152.0")
-                        .withNetwork(network)
-                        .withNetworkAliases("otel-collector")
-                        .withCopyFileToContainer(
-                                MountableFile.forClasspathResource("otel-collector-e2e-config.yaml"),
-                                "/etc/otel-collector-config.yaml")
-                        .withCommand("--config=/etc/otel-collector-config.yaml")
-                        .withExposedPorts(4317, 8889)
-                        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("otel-collector")))
-                        .waitingFor(Wait.forLogMessage(".*Everything is ready.*", 1));
-                collector.start();
-
-                // --- Prometheus ---
-                // Scrapes the collector's prometheus exporter (port 8889).
-                // This pull-based path preserves # TYPE / # HELP, so
-                // /api/v1/metadata returns gauge/counter rather than "unknown".
-                prometheus = new GenericContainer<>("prom/prometheus:v3.11.3")
-                        .withNetwork(network)
-                        .withNetworkAliases("prometheus")
-                        .withCopyFileToContainer(
-                                MountableFile.forClasspathResource("prometheus-e2e.yml"),
-                                "/etc/prometheus/prometheus.yml")
-                        .withCommand("--config.file=/etc/prometheus/prometheus.yml")
-                        .withExposedPorts(9090)
-                        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("prometheus")))
-                        .waitingFor(Wait.forHttp("/-/ready").forPort(9090));
-                prometheus.start();
-
-                // gRPC endpoint reachable from the test JVM (mapped host port)
-                String collectorEndpointFromHost =
-                        "http://" + collector.getHost() + ":" + collector.getMappedPort(4317);
-
-                // --- Kafka (KRaft, apache/kafka:4.2.0) with plugin ---
-                // KafkaContainer from testcontainers:kafka 1.19.8 only supports Confluent images,
-                // so we use GenericContainer with apache/kafka in KRaft mode instead.
-                //
-                // We expose two listeners:
-                //   PLAINTEXT (9092) - for internal Docker network traffic
-                //   EXTERNAL  (19092) - bound to a fixed host port so the test JVM can connect
-                //
-                // The broker is configured with the OTLP plugin so it sends its own broker
-                // metrics to the collector. The test producer is separately configured below
-                // to also use the plugin.
-                kafka = new GenericContainer<>("apache/kafka:4.2.0")
-                        .withNetwork(network)
-                        .withNetworkAliases("kafka")
-                        .withEnv("KAFKA_NODE_ID", "1")
-                        .withEnv("KAFKA_PROCESS_ROLES", "broker,controller")
-                        .withEnv(
-                                "KAFKA_LISTENERS",
-                                "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:19092")
-                        .withEnv(
-                                "KAFKA_ADVERTISED_LISTENERS",
-                                "PLAINTEXT://kafka:9092,EXTERNAL://localhost:" + KAFKA_HOST_PORT)
-                        .withEnv(
-                                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
-                                "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT")
-                        .withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@kafka:9093")
-                        .withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
-                        .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "PLAINTEXT")
-                        // Plugin in the broker - sends broker-side metrics to collector
-                        // (both Kafka SPI and Yammer/Coda Hale registries — single reporter handles both).
-                        .withEnv("KAFKA_METRIC_REPORTERS", "dev.monedula.metricsreporter.OtlpMetricReporter")
-                        .withEnv("KAFKA_OTLP_METRIC_REPORTER_ENDPOINT", "http://otel-collector:4317")
-                        .withEnv("KAFKA_OTLP_METRIC_REPORTER_TRANSPORT", "grpc")
-                        .withEnv("KAFKA_OTLP_METRIC_REPORTER_INTERVAL_MS", "5000")
-                        // OtlpMetricReporterConfig requires timeout.ms < interval.ms strictly.
-                        // The default timeout (5000) equals our test interval, so set it lower.
-                        .withEnv("KAFKA_OTLP_METRIC_REPORTER_TIMEOUT_MS", "3000")
-                        .withCopyFileToContainer(
-                                // Stable-name JAR produced by the quickstartShadowJar task that
-                                // finalises shadowJar — avoids hard-coding the project version here.
-                                // Lives in a separate build dir so it doesn't collide with the
-                                // versioned shadowJar output that release publishing consumes.
-                                MountableFile.forHostPath("../build/quickstart-libs/monedula-metrics-reporter.jar"),
-                                "/opt/kafka/libs/monedula-metrics-reporter.jar")
-                        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka")))
-                        .waitingFor(Wait.forLogMessage(".*Kafka Server started.*", 1));
-                kafka.setPortBindings(List.of(KAFKA_HOST_PORT + ":19092"));
-                kafka.start();
+                String collectorEndpointFromHost = stack.collectorGrpcEndpointFromHost();
 
                 // --- Produce messages to generate producer-side metrics ---
                 // The KafkaProducer is also configured with our OTLP metric reporter so that
@@ -180,7 +208,7 @@ class KafkaOtlpE2ETest {
                 // --- Assert producer metric appears in Prometheus ---
                 // Task A switched to empty units so Prometheus no longer appends "_ratio";
                 // we still accept both names for forward/backward tolerance.
-                String prometheusUrl = "http://" + prometheus.getHost() + ":" + prometheus.getMappedPort(9090);
+                String prometheusUrl = stack.prometheusUrl();
                 String[] producerCandidates = {
                     // The test-JVM producer uses our reporter, and Kafka sets
                     // _namespace="kafka.producer" on the client side, so the SPI
@@ -291,9 +319,150 @@ class KafkaOtlpE2ETest {
                         "Expected kafka_controller_kafkacontroller_activecontrollercount "
                                 + "to have type=gauge metadata, got: " + mdResponse.body());
             } finally {
-                if (kafka != null) kafka.stop();
-                if (prometheus != null) prometheus.stop();
-                if (collector != null) collector.stop();
+                stack.stopAll();
+            }
+        }
+    }
+
+    /**
+     * End-to-end test for KIP-714 client telemetry: a producer with
+     * {@code enable.metrics.push=true} pushes its own OTLP telemetry to the broker via
+     * the KIP-714 PushTelemetry RPC. The broker's plugin receiver forwards each payload to
+     * the OTel collector (also used by the existing test). The enriched series must arrive
+     * in Prometheus carrying the {@code kafka_cluster_id} label added by the broker's
+     * ClientMetricsEnricher.
+     *
+     * <p>Pipeline under test:
+     *   KafkaProducer (KIP-714 push, no OtlpMetricReporter on the client side)
+     *     → broker ClientTelemetryReceiverImpl (our plugin, broker side)
+     *     → ClientTelemetryForwarder → OtlpExporter
+     *     → OpenTelemetry Collector (OTLP gRPC, prometheus pull exporter on :8889)
+     *     ← Prometheus (scrapes collector)
+     */
+    @Test
+    void kip714_client_telemetry_lands_in_prometheus_with_cluster_id_label() throws Exception {
+        try (Network network = Network.newNetwork()) {
+            // Same stack as the producer test; the broker has client telemetry enabled by default
+            // (CLIENT_TELEMETRY_ENABLED=true). The plugin's ClientTelemetryReceiverImpl sits idle
+            // until a subscription is created; after that Kafka tells each connecting client what
+            // to push and how often.
+            E2eStack stack = startStack(network, "-kip714");
+            try {
+                // --- Step 1: Create a client-metrics subscription via AdminClient ---
+                // This is what activates KIP-714 on the broker: without a subscription the broker
+                // returns an empty GetTelemetrySubscriptions response and clients don't push.
+                // ConfigResource.Type.CLIENT_METRICS is available since Kafka 3.7 (KIP-714).
+                //
+                // The "metrics" value MUST be "*" to subscribe to ALL client metrics. Kafka 4.2.0's
+                // ClientMetricsConfigs defines ALL_SUBSCRIBED_METRICS = "*" and METRICS_DEFAULT =
+                // List.of() (empty). An empty string therefore selects NO metrics, so clients
+                // complete the GetTelemetrySubscriptions handshake but never push — which is exactly
+                // the false-positive trap an earlier version of this test fell into.
+                Properties adminProps = new Properties();
+                adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + KAFKA_HOST_PORT);
+                ConfigResource sub = new ConfigResource(ConfigResource.Type.CLIENT_METRICS, "e2e-sub");
+                try (Admin admin = Admin.create(adminProps)) {
+                    Collection<AlterConfigOp> ops = List.of(
+                            // "*" = subscribe to ALL client metrics (ClientMetricsConfigs.ALL_SUBSCRIBED_METRICS).
+                            new AlterConfigOp(new ConfigEntry("metrics", "*"), AlterConfigOp.OpType.SET),
+                            // Push every 5 seconds; clients push on this interval once subscribed.
+                            new AlterConfigOp(new ConfigEntry("interval.ms", "5000"), AlterConfigOp.OpType.SET));
+                    admin.incrementalAlterConfigs(Map.of(sub, ops))
+                            .all()
+                            .get(30, java.util.concurrent.TimeUnit.SECONDS);
+
+                    // Confirm the subscription is fully applied BEFORE clients connect: describe the
+                    // CLIENT_METRICS resource and assert it shows our values. This rules out a race
+                    // where clients do GetTelemetrySubscriptions before the config has propagated.
+                    Config applied = admin.describeConfigs(List.of(sub))
+                            .all()
+                            .get(30, java.util.concurrent.TimeUnit.SECONDS)
+                            .get(sub);
+                    ConfigEntry metricsEntry = applied.get("metrics");
+                    ConfigEntry intervalEntry = applied.get("interval.ms");
+                    assertTrue(
+                            metricsEntry != null && "*".equals(metricsEntry.value()),
+                            "Expected CLIENT_METRICS subscription 'metrics' = '*', got: " + metricsEntry);
+                    assertTrue(
+                            intervalEntry != null && "5000".equals(intervalEntry.value()),
+                            "Expected CLIENT_METRICS subscription 'interval.ms' = '5000', got: " + intervalEntry);
+                }
+
+                // --- Step 2: Run a producer and consumer with KIP-714 push enabled ---
+                // These are plain Kafka clients — no OtlpMetricReporter on the client side.
+                // They push their OTLP telemetry to the broker via PushTelemetry, which our
+                // plugin receives. enable.metrics.push is true by default, set explicitly for clarity.
+                Properties producerProps = new Properties();
+                producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + KAFKA_HOST_PORT);
+                producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                producerProps.put("enable.metrics.push", "true");
+
+                Properties consumerProps = new Properties();
+                consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + KAFKA_HOST_PORT);
+                consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "e2e-kip714-group");
+                consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+                consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+                consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+                consumerProps.put("enable.metrics.push", "true");
+
+                // Keep both clients alive comfortably longer than interval.ms (5s) — produce/consume
+                // real traffic for ~30s so each client refreshes subscriptions, accumulates metrics,
+                // and performs several PushTelemetry calls. We poll in a loop rather than sleeping so
+                // the clients stay active (heartbeats, fetches) the whole time.
+                String prometheusUrl = stack.prometheusUrl();
+                try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps);
+                        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps)) {
+                    consumer.subscribe(List.of("kip714-test-topic"));
+                    long kip714DeadlineMs = System.currentTimeMillis() + 30_000;
+                    int sent = 0;
+                    while (System.currentTimeMillis() < kip714DeadlineMs) {
+                        producer.send(new ProducerRecord<>("kip714-test-topic", "k-" + sent, "v-" + sent));
+                        sent++;
+                        consumer.poll(Duration.ofMillis(500));
+                    }
+                    producer.flush();
+                }
+
+                // --- Step 3a (PRIMARY proof): our forwarder actually forwarded a client push ---
+                // monedula_reporter_clienttelemetry_forwarded_total is emitted by OUR
+                // ClientTelemetryForwarder and is only nonzero if our broker-side
+                // ClientTelemetryReceiverImpl received a client payload AND the forwarder exported it.
+                // This is the unambiguous gate: it would stay 0 if the receiver were deleted. An
+                // earlier version of this test passed without this gate (a broker SPI series happened
+                // to carry kafka_cluster_id), so this assertion is what makes the test a TRUE proof.
+                assertTrue(
+                        awaitLabeledMetric(
+                                prometheusUrl,
+                                "monedula_reporter_clienttelemetry_forwarded_total > 0",
+                                Duration.ofSeconds(60)),
+                        "Expected monedula_reporter_clienttelemetry_forwarded_total > 0 — our KIP-714 "
+                                + "receiver/forwarder never forwarded a client telemetry payload (clients "
+                                + "are not pushing, or the receiver is broken)");
+
+                // --- Step 3b (enrichment proof): a CLIENT-ONLY series carries the broker cluster id ---
+                // The KIP-714 client pushes metrics under the org.apache.kafka.producer.* and
+                // org.apache.kafka.consumer.* namespaces (verified against the live collector at
+                // detailed verbosity). The broker's own SPI metrics only ever use the
+                // org.apache.kafka.server.* namespace, so org_apache_kafka_(producer|consumer)_*
+                // series can ONLY come from a client push through our forwarder — there is no broker
+                // series that matches. Requiring kafka_cluster_id!="" on top proves our enricher
+                // attached the broker identity to the client-originated series.
+                //
+                // (We deliberately do NOT key on client_instance_id: the client does not place it in
+                // the OTLP resource attributes our converter sees — the pushed resource only carries
+                // the broker enrichment our plugin adds — so the namespace split is the reliable
+                // client/broker discriminator here.)
+                assertTrue(
+                        awaitLabeledMetric(
+                                prometheusUrl,
+                                "{__name__=~\"org_apache_kafka_(producer|consumer)_.*\",kafka_cluster_id!=\"\"}",
+                                Duration.ofSeconds(60)),
+                        "Expected at least one client-originated org_apache_kafka_(producer|consumer)_* "
+                                + "series (a namespace only KIP-714 clients emit, never the broker) carrying "
+                                + "kafka_cluster_id — proves a client push reached Prometheus with broker enrichment");
+            } finally {
+                stack.stopAll();
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kafkaVersion=4.2.0
 otelVersion=1.40.0
 otelInstrumentationVersion=2.7.0-alpha
+otelProtoVersion=1.7.0-alpha
 junitBomVersion=5.10.2
 yammerMetricsVersion=2.2.0
 mockitoVersion=5.23.0

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -115,3 +115,109 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+
+  # --- Demo client: enables client telemetry out-of-the-box ---
+  # Waits for the cluster, creates a KIP-714 client-metrics subscription
+  # (metrics="*" = all client metrics), then runs a continuous produce+consume
+  # loop. The console/perf clients push their own OTLP telemetry (KIP-714,
+  # enable.metrics.push defaults true); the broker plugin forwards it to the
+  # collector, populating the client dashboards. Also generates broker-side
+  # traffic for the existing Production/Consumption dashboards.
+  demo:
+    image: apache/kafka:4.2.0
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        set -u
+        echo "demo: waiting for kafka..."
+        until /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka1:9092 --list >/dev/null 2>&1; do sleep 3; done
+        echo "demo: creating client-metrics subscription (idempotent)"
+        /opt/kafka/bin/kafka-client-metrics.sh --bootstrap-server kafka1:9092 --alter \
+          --name quickstart-clients --metrics "*" --interval 5000 || true
+        echo "demo: creating topic"
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka1:9092 --create --if-not-exists \
+          --topic quickstart-demo --partitions 3 --replication-factor 3 || true
+        echo "demo: starting consumer"
+        /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka1:9092 \
+          --topic quickstart-demo --group quickstart-demo-group >/dev/null 2>&1 &
+        echo "demo: starting continuous producer"
+        while true; do
+          /opt/kafka/bin/kafka-producer-perf-test.sh --topic quickstart-demo \
+            --num-records 30000 --record-size 256 --throughput 1000 \
+            --producer-props bootstrap.servers=kafka1:9092 || true
+          sleep 5
+        done
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+    restart: unless-stopped
+
+  # --- librdkafka demo client (confluent-kafka-python) — opt-in via profile ---
+  # Run INSTEAD of the Java `demo` (stop that first) to see which panels populate
+  # for a non-JVM, librdkafka-based client. librdkafka (>=2.5) supports KIP-714 and
+  # pushes only the standard org.apache.kafka.* metrics (no vendor extras), so the
+  # dashboards' "Extended" panels stay empty for it.
+  # Enable with:  docker compose --project-directory quickstart --profile librdkafka up -d demo-librdkafka
+  #
+  # The init container (re)creates the client-metrics subscription so this profile is
+  # self-contained — it works even when the Java `demo` is stopped. The broker keeps the
+  # subscription in cluster metadata, which the quickstart brokers do not persist, so it
+  # can vanish after a broker recreate. confluent-kafka-python's AdminClient cannot create
+  # a CLIENT_METRICS subscription, hence the apache/kafka CLI image here.
+  demo-librdkafka-init:
+    image: apache/kafka:4.2.0
+    profiles: ["librdkafka"]
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        set -e
+        until /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka1:9092 --list >/dev/null 2>&1; do sleep 3; done
+        /opt/kafka/bin/kafka-client-metrics.sh --bootstrap-server kafka1:9092 --alter \
+          --name quickstart-clients --metrics "*" --interval 5000
+        echo "demo-librdkafka-init: client-metrics subscription ensured"
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+    restart: "no"
+
+  demo-librdkafka:
+    image: python:3.12-slim
+    profiles: ["librdkafka"]
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        pip install --no-cache-dir 'confluent-kafka>=2.5.0' >/dev/null
+        cat > /demo.py <<'PY'
+        import threading, time
+        from confluent_kafka import Producer, Consumer
+        BOOT = "kafka1:9092"
+        TOPIC = "quickstart-librdkafka-demo"
+        # enable.metrics.push defaults true in librdkafka >=2.5; set explicitly for clarity.
+        p = Producer({"bootstrap.servers": BOOT, "enable.metrics.push": True, "client.id": "librdkafka-demo-producer"})
+        c = Consumer({"bootstrap.servers": BOOT, "group.id": "librdkafka-demo-group",
+                      "auto.offset.reset": "earliest", "enable.metrics.push": True, "client.id": "librdkafka-demo-consumer"})
+        c.subscribe([TOPIC])
+        def consume():
+            while True:
+                m = c.poll(1.0)
+        threading.Thread(target=consume, daemon=True).start()
+        n = 0
+        while True:
+            p.produce(TOPIC, key=f"k{n}".encode(), value=f"v{n}".encode()); n += 1
+            if n % 1000 == 0: p.flush()
+            time.sleep(0.005)  # ~200 msg/s
+        PY
+        python /demo.py
+    depends_on:
+      kafka1:
+        condition: service_started
+      kafka2:
+        condition: service_started
+      kafka3:
+        condition: service_started
+      demo-librdkafka-init:
+        condition: service_completed_successfully
+    restart: unless-stopped

--- a/quickstart/grafana/provisioning/dashboards/kafka-client-consumers.json
+++ b/quickstart/grafana/provisioning/dashboards/kafka-client-consumers.json
@@ -1,0 +1,1518 @@
+{
+  "id": null,
+  "uid": "kafka-otlp-client-consumers",
+  "title": "Kafka Consumers (client)",
+  "description": "KIP-714 client-side consumer metrics. Requires a client-metrics subscription on the broker (bootstrap.servers config + ClientMetrics subscription resource).",
+  "tags": [
+    "kafka",
+    "otlp",
+    "consumer-client"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "",
+  "editable": true,
+  "graphTooltip": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_consumer_connection_count, kafka_cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Cluster"
+      },
+      {
+        "name": "client",
+        "type": "query",
+        "label": "Client",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_consumer_connection_creation_total, client_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "group",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_consumer_coordinator_assigned_partitions, group_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Group"
+      },
+      {
+        "name": "topic",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_consumer_fetch_manager_records_consumed_rate, topic)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Topic"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "## Consumer (client) metrics\nPanels are grouped by KIP-714 portability. **Standard** panels are populated by *any* KIP-714 client (Java, librdkafka \u22652.5 \u2192 confluent-kafka Python/Go/.NET/Node, \u2026). **Extended** panels use Java/JVM-client-only metrics and will be **empty for librdkafka-based clients**. (Use the **Client** dropdown above to filter by `client_id`. Clients are now distinguishable, so the Java and librdkafka demos can run **side by side** and be compared \u2014 see the quickstart README.)"
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Standard \u2014 populated by all KIP-714 clients",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "panels": []
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Assigned Partitions",
+      "description": "Total number of partitions assigned across all consumer group members.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (group_id, group_member_id) (org_apache_kafka_consumer_coordinator_assigned_partitions{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"}))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Fetch Latency",
+      "description": "Average and max fetch latency across all consumers.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_fetch_manager_fetch_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "avg",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_consumer_fetch_manager_fetch_latency_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "max",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Rebalance Latency",
+      "description": "Average and maximum rebalance latency.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_rebalance_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "avg",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_consumer_coordinator_rebalance_latency_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "max",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Commit Latency",
+      "description": "Average and max consumer offset commit latency.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_commit_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "avg",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_consumer_coordinator_commit_latency_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "max",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Poll Idle Ratio",
+      "description": "Average consumer poll idle ratio \u2014 the fraction of time the consumer spent waiting for records.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_poll_idle_ratio_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "idle ratio",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Per-broker Request Latency",
+      "description": "Average request latency broken down by broker node.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg by (node_id) (org_apache_kafka_consumer_node_request_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\",node_id=~\"(node-)?[0-9]{1,9}\"})",
+          "legendFormat": "{{node_id}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Connection Creation",
+      "description": "Connection creation rate (rate/s from counter) and the gauge-based creation rate metric.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_consumer_connection_creation_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"}[5m]))",
+          "legendFormat": "create/s",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_consumer_connection_creation_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "rate",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Extended \u2014 JVM/Java client only (empty for librdkafka clients)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Records Consumed/sec",
+      "description": "Total consumer record consumption rate across all consumers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_consumer_fetch_manager_records_consumed_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Bytes Consumed/sec",
+      "description": "Total consumer bytes consumed per second across all consumers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_consumer_fetch_manager_bytes_consumed_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Max Records Lag",
+      "description": "Maximum consumer records lag across all consumers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max(org_apache_kafka_consumer_fetch_manager_records_lag_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Rebalances/hour",
+      "description": "Total rebalance rate per hour across all consumer groups.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(org_apache_kafka_consumer_coordinator_rebalance_rate_per_hour{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Records Consumed by Group",
+      "description": "Per-group consumer record consumption rate.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (group_id) (org_apache_kafka_consumer_fetch_manager_records_consumed_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "{{group_id}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Bytes Consumed by Topic",
+      "description": "Per-topic consumer bytes consumed per second.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (org_apache_kafka_consumer_fetch_manager_bytes_consumed_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Records Lag by Topic/Partition",
+      "description": "Maximum consumer records lag broken down by topic and partition.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max by (topic,partition) (org_apache_kafka_consumer_fetch_manager_records_lag{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}}-{{partition}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Max Lag by Group",
+      "description": "Maximum records lag per consumer group.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max by (group_id) (org_apache_kafka_consumer_fetch_manager_records_lag_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "{{group_id}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Records Lead (min)",
+      "description": "Minimum records lead broken down by topic and partition.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "min by (topic,partition) (org_apache_kafka_consumer_fetch_manager_records_lead_min{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}}-{{partition}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Failed Rebalance & Join/Sync",
+      "description": "Failed rebalance rate per hour, and average join and sync time.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(org_apache_kafka_consumer_coordinator_failed_rebalance_rate_per_hour{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "failed/hr",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_join_time_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "join ms",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_sync_time_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "sync ms",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Partition Assign/Revoke/Lost Latency",
+      "description": "Average latency for partition assigned, revoked, and lost callbacks.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_partition_assigned_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "assigned",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_partition_revoked_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "revoked",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_consumer_coordinator_partition_lost_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "lost",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Commit Rate",
+      "description": "Consumer offset commit rate per second.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(org_apache_kafka_consumer_coordinator_commit_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "commits/s",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Time Between Poll",
+      "description": "Average and max time between consumer poll calls.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 58
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_consumer_time_between_poll_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "avg ms",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_consumer_time_between_poll_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "max ms",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 24,
+      "type": "stat",
+      "title": "Liveness",
+      "description": "Maximum time since last heartbeat and last poll across all consumers.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 58
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max(org_apache_kafka_consumer_coordinator_last_heartbeat_seconds_ago{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "last heartbeat s",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_consumer_last_poll_seconds_ago{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "legendFormat": "last poll s",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 25,
+      "type": "table",
+      "title": "Members",
+      "description": "Per-consumer-group-member snapshot: assigned partitions, max lag, and last heartbeat.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max by (group_id, group_member_id) (org_apache_kafka_consumer_coordinator_assigned_partitions{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max by (group_id, group_member_id) (org_apache_kafka_consumer_fetch_manager_records_lag_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max by (group_id, group_member_id) (org_apache_kafka_consumer_coordinator_last_heartbeat_seconds_ago{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",group_id=~\"$group\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Assigned Partitions"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max Lag"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #C"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Last Heartbeat (s)"
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Max Lag",
+            "desc": true
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "otel_scope_name": true,
+              "kafka_cluster_id": true,
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Assigned Partitions",
+              "Value #B": "Max Lag",
+              "Value #C": "Last Heartbeat (s)"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/quickstart/grafana/provisioning/dashboards/kafka-client-producers.json
+++ b/quickstart/grafana/provisioning/dashboards/kafka-client-producers.json
@@ -1,0 +1,1204 @@
+{
+  "id": null,
+  "uid": "kafka-otlp-client-producers",
+  "title": "Kafka Producers (client)",
+  "description": "KIP-714 client-side producer metrics. Requires a client-metrics subscription on the broker (bootstrap.servers config + ClientMetrics subscription resource).",
+  "tags": [
+    "kafka",
+    "otlp",
+    "producer-client"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "",
+  "editable": true,
+  "graphTooltip": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_producer_connection_count, kafka_cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Cluster"
+      },
+      {
+        "name": "client",
+        "type": "query",
+        "label": "Client",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_producer_connection_creation_total, client_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "topic",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(org_apache_kafka_producer_topic_record_send_rate, topic)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Topic"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "## Producer (client) metrics\nPanels are grouped by KIP-714 portability. **Standard** panels are populated by *any* KIP-714 client (Java, librdkafka \u22652.5 \u2192 confluent-kafka Python/Go/.NET/Node, \u2026). **Extended** panels use Java/JVM-client-only metrics and will be **empty for librdkafka-based clients**. (Use the **Client** dropdown above to filter by `client_id`. Clients are now distinguishable, so the Java and librdkafka demos can run **side by side** and be compared \u2014 see the quickstart README.)"
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Standard \u2014 populated by all KIP-714 clients",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "panels": []
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Avg Request Latency",
+      "description": "Average request latency across all producers.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_request_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Connection Creation/s",
+      "description": "Total connection creation rate across all producers.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_connection_creation_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Request Latency & Throttle",
+      "description": "Producer request latency (avg/max) and throttle time.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_request_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "req avg",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_producer_request_latency_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "req max",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_producer_produce_throttle_time_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "throttle",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Per-broker Request Latency",
+      "description": "Average request latency broken down by broker node.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg by (node_id) (org_apache_kafka_producer_node_request_latency_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",node_id=~\"(node-)?[0-9]{1,9}\"})",
+          "legendFormat": "{{node_id}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Record Queue Time",
+      "description": "Average and max time records spend in the producer queue before being sent.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_record_queue_time_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "avg",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "max(org_apache_kafka_producer_record_queue_time_max{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "max",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Connection Creation",
+      "description": "Connection creation rate (rate/s from counter) and the gauge-based creation rate metric.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_connection_creation_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "legendFormat": "create/s",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_producer_connection_creation_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "rate",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "Extended \u2014 JVM/Java client only (empty for librdkafka clients)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Record Send Rate",
+      "description": "Total producer record send rate across all producers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_record_send_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Outgoing Bytes/sec",
+      "description": "Total outgoing bytes per second from all producers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_outgoing_byte_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Record Error Rate",
+      "description": "Total record error rate across all producers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_record_error_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Active Connections",
+      "description": "Total active connections across all producers.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(org_apache_kafka_producer_connection_count{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto",
+        "orientation": "auto"
+      }
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Record Send Rate by Topic",
+      "description": "Per-topic producer record send rate.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (org_apache_kafka_producer_topic_record_send_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Bytes/sec by Topic",
+      "description": "Per-topic producer outgoing bytes per second.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (org_apache_kafka_producer_topic_byte_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Batch Size & Records/Request",
+      "description": "Average batch size in bytes and average records per request.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_batch_size_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "batch bytes",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_producer_records_per_request_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "records/req",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Buffer",
+      "description": "Buffer available bytes, exhausted rate, and buffer pool wait ratio.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_buffer_available_bytes{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "available",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_buffer_exhausted_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "legendFormat": "exhausted/s",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "avg(org_apache_kafka_producer_bufferpool_wait_ratio{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "wait ratio",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Compression Ratio",
+      "description": "Average compression ratio across all producers.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "avg(org_apache_kafka_producer_compression_rate_avg{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "ratio",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Error & Retry Rate by Topic",
+      "description": "Per-topic record error rate and retry rate.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (org_apache_kafka_producer_topic_record_error_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}} error",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "sum by (topic) (org_apache_kafka_producer_topic_record_retry_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\",topic=~\"$topic\"})",
+          "legendFormat": "{{topic}} retry",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Connections & In-flight",
+      "description": "Connection close rate and in-flight requests.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(org_apache_kafka_producer_connection_close_total{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}[5m]))",
+          "legendFormat": "close/s",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        },
+        {
+          "expr": "sum(org_apache_kafka_producer_requests_in_flight{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"})",
+          "legendFormat": "in-flight",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "table",
+      "title": "Top Topics by Send Rate",
+      "description": "Top 10 topics ranked by producer record send rate.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (topic) (org_apache_kafka_producer_topic_record_send_rate{client_id=~\"$client\",kafka_cluster_id=~\"$cluster\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "align": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Send Rate"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Send Rate",
+            "desc": true
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/dev/monedula/metricsreporter/MetricCollector.java
+++ b/src/main/java/dev/monedula/metricsreporter/MetricCollector.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,21 @@ public class MetricCollector {
     /** Wall-clock duration of the previous tick in milliseconds. */
     private volatile long lastExportDurationMs;
 
+    /**
+     * Snapshot of the client-telemetry forwarder's self-monitoring counters. A named record —
+     * rather than a positional array — so the counter-to-metric mapping is compiler-checked at
+     * both the producing lambda (OtlpMetricReporter) and the consuming export below.
+     */
+    public record ClientTelemetryCounters(
+            long received, long forwarded, long dropped, long unsupportedMetricsDropped, long queueDepth) {}
+
+    /**
+     * Optional source of client-telemetry counters. Null until a forwarder is wired (client
+     * telemetry enabled). Read each tick so these self-metrics ride the same export as the rest
+     * of the reporter self-monitoring.
+     */
+    private volatile Supplier<ClientTelemetryCounters> clientTelemetryCounters;
+
     public MetricCollector(
             MetricRegistry registry,
             MetricDataMapper mapper,
@@ -71,6 +87,11 @@ public class MetricCollector {
             t.setUncaughtExceptionHandler((th, ex) -> log.error("Uncaught exception in metric export thread", ex));
             return t;
         });
+    }
+
+    /** Attach (or clear, with {@code null}) the client-telemetry counter source. */
+    public void setClientTelemetryCounters(Supplier<ClientTelemetryCounters> counters) {
+        this.clientTelemetryCounters = counters;
     }
 
     /** Attach an optional Yammer source. May be called any time before/after start. */
@@ -119,6 +140,11 @@ public class MetricCollector {
         return mapper;
     }
 
+    /** Run a single export synchronously. Visible for tests. */
+    void exportOnceForTest() {
+        exportTick();
+    }
+
     /** Total exports that completed successfully since this collector started. Exposed for tests. */
     long exportSuccessCount() {
         return exportSuccessCount.sum();
@@ -159,8 +185,43 @@ public class MetricCollector {
                     now,
                     "monedula_reporter_export_duration_ms",
                     "Wall-clock duration of the previous export tick in milliseconds",
-                    "ms",
+                    // Unit intentionally left blank: the "ms" is already in the metric name, and a
+                    // non-empty OTLP unit makes the Prometheus exporter append a "_milliseconds"
+                    // suffix (yielding monedula_reporter_export_duration_ms_milliseconds), which
+                    // breaks the documented name and the quickstart kafka-metrics dashboard.
+                    "",
                     lastExportDurationMs));
+
+            Supplier<ClientTelemetryCounters> ctc = this.clientTelemetryCounters;
+            if (ctc != null) {
+                ClientTelemetryCounters c = ctc.get();
+                data.add(selfSum(
+                        now,
+                        "monedula_reporter_clienttelemetry_received_total",
+                        "Total KIP-714 client telemetry payloads accepted since the reporter started",
+                        c.received()));
+                data.add(selfSum(
+                        now,
+                        "monedula_reporter_clienttelemetry_forwarded_total",
+                        "Total KIP-714 client telemetry payloads forwarded to the collector since the reporter started",
+                        c.forwarded()));
+                data.add(selfSum(
+                        now,
+                        "monedula_reporter_clienttelemetry_dropped_total",
+                        "Total KIP-714 client telemetry payloads dropped (queue full or export failure) since the reporter started",
+                        c.dropped()));
+                data.add(selfSum(
+                        now,
+                        "monedula_reporter_clienttelemetry_unsupported_metrics_dropped_total",
+                        "Total client telemetry metric data points dropped as unsupported types since the reporter started",
+                        c.unsupportedMetricsDropped()));
+                data.add(selfGauge(
+                        now,
+                        "monedula_reporter_clienttelemetry_queue_depth",
+                        "Current depth of the client telemetry forwarder queue",
+                        "",
+                        c.queueDepth()));
+            }
 
             var result = exporter.export(data);
             result.join(timeoutMs, TimeUnit.MILLISECONDS);

--- a/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporter.java
+++ b/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporter.java
@@ -3,6 +3,10 @@
 package dev.monedula.metricsreporter;
 
 import com.yammer.metrics.core.MetricsRegistry;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsConverter;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher;
+import dev.monedula.metricsreporter.clienttelemetry.ClientTelemetryForwarder;
+import dev.monedula.metricsreporter.clienttelemetry.ClientTelemetryReceiverImpl;
 import dev.monedula.metricsreporter.yammer.YammerMetricDataMapper;
 import dev.monedula.metricsreporter.yammer.YammerMetricRegistry;
 import java.util.Collections;
@@ -13,6 +17,8 @@ import java.util.UUID;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.server.telemetry.ClientTelemetry;
+import org.apache.kafka.server.telemetry.ClientTelemetryReceiver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * {@code noop} flag. JVM-metrics setup and teardown are delegated to
  * {@link JvmMetricsLifecycle}, which owns its own volatile "running" predicate.
  */
-public class OtlpMetricReporter implements MetricsReporter {
+public class OtlpMetricReporter implements MetricsReporter, ClientTelemetry {
 
     private static final Logger log = LoggerFactory.getLogger(OtlpMetricReporter.class);
 
@@ -61,6 +67,15 @@ public class OtlpMetricReporter implements MetricsReporter {
      * read its {@code resource} field without going through OTel internals.
      */
     volatile JvmMetricsLifecycle jvmMetrics;
+
+    /**
+     * KIP-714 forwarder + receiver. Both stay {@code null} when client telemetry is
+     * disabled or the reporter is in no-op mode. Package-private so tests can assert on
+     * client-telemetry wiring.
+     */
+    volatile ClientTelemetryForwarder clientTelemetryForwarder;
+
+    private volatile ClientTelemetryReceiver clientTelemetryReceiver;
 
     /**
      * Per-reporter {@code service.instance.id} (OTel semantic convention). Generated
@@ -138,6 +153,52 @@ public class OtlpMetricReporter implements MetricsReporter {
                     log.warn("Failed to start JVM runtime metrics, continuing without them", t);
                 }
             }
+
+            if (cfg.clientTelemetryEnabled()) {
+                // Isolated like the JVM-metrics block above: a failure in this optional, additive
+                // subsystem must degrade ONLY client telemetry — never demote the already-started
+                // SPI/Yammer/JVM pipelines to no-op (Kafka availability beats metrics completeness).
+                try {
+                    ClientMetricsEnricher enricher = new ClientMetricsEnricher(
+                            cfg.clientTelemetryEnrichBroker(),
+                            cfg.clientTelemetryEnrichClientIdentity(),
+                            cfg.clientTelemetryEnrichClientId(),
+                            cfg.clientTelemetryEnrichClientInstanceId());
+                    ClientTelemetryForwarder forwarder = new ClientTelemetryForwarder(
+                            OtlpExporterFactory.create(cfg),
+                            new ClientMetricsConverter(enricher),
+                            cfg.clientTelemetryQueueCapacity(),
+                            cfg.timeoutMs());
+                    // Publish the field before any further setup (which builds the exporter eagerly), so a
+                    // failure in setBrokerIdentity/start still routes the forwarder's exporter through the
+                    // cleanup in the catch below (and through teardown() on close).
+                    this.clientTelemetryForwarder = forwarder;
+                    forwarder.setBrokerIdentity(contextLabels);
+                    forwarder.start();
+                    collector.setClientTelemetryCounters(() -> new MetricCollector.ClientTelemetryCounters(
+                            forwarder.receivedCount(),
+                            forwarder.forwardedCount(),
+                            forwarder.droppedCount(),
+                            forwarder.unsupportedMetricsDroppedCount(),
+                            forwarder.queueDepth()));
+                    this.clientTelemetryReceiver = new ClientTelemetryReceiverImpl(
+                            this::submitClientTelemetry, cfg.clientTelemetryEnrichClientIdentity());
+                    log.info("OtlpMetricReporter client telemetry (KIP-714) receiver enabled");
+                } catch (Throwable t) {
+                    log.warn("Failed to start client telemetry (KIP-714) forwarding, continuing without it", t);
+                    ClientTelemetryForwarder partial = this.clientTelemetryForwarder;
+                    if (partial != null) {
+                        try {
+                            partial.stop(); // releases the forwarder's exporter even if start() never ran
+                        } catch (Exception stopError) {
+                            log.warn("Error stopping partially-initialized client telemetry forwarder", stopError);
+                        }
+                        this.clientTelemetryForwarder = null;
+                    }
+                    this.clientTelemetryReceiver = null;
+                    collector.setClientTelemetryCounters(null);
+                }
+            }
         } catch (Exception e) {
             // Kafka availability comes first (see docs/assumptions.md): a bad reporter config
             // must not crash the broker. Configure() exceptions propagate through
@@ -185,6 +246,30 @@ public class OtlpMetricReporter implements MetricsReporter {
         teardown();
     }
 
+    @Override
+    public ClientTelemetryReceiver clientReceiver() {
+        // Null in no-op mode or when disabled — the broker then won't advertise the capability.
+        // Kafka calls this once and caches the result. The receiver stays valid across a
+        // re-configure() because it delegates to the CURRENT forwarder via a volatile read
+        // (submitClientTelemetry below) rather than binding to the forwarder that existed when
+        // it was constructed. (MetricsReporter extends Reconfigurable, but this reporter
+        // overrides neither reconfigurableConfigs() nor reconfigure(), so Kafka itself never
+        // re-invokes configure() on a live instance — the live read matters for the explicit
+        // re-init path this class supports and tests.)
+        return noop ? null : clientTelemetryReceiver;
+    }
+
+    /**
+     * {@link ClientTelemetryReceiverImpl.Submitter} target. Reads the volatile forwarder field at
+     * call time — mirroring how {@link #metricChange} reads {@code registry} — so a receiver
+     * instance Kafka cached from an earlier {@link #configure} always feeds the live forwarder,
+     * never one already stopped by {@link #teardown()}.
+     */
+    private boolean submitClientTelemetry(byte[] payload, ClientMetricsEnricher.ClientIdentity clientIdentity) {
+        ClientTelemetryForwarder f = this.clientTelemetryForwarder;
+        return f != null && f.submit(payload, clientIdentity);
+    }
+
     /**
      * Release any resources that may have been allocated during {@link #configure}: the
      * scheduled export thread and its OTLP exporter, plus the optional JVM-runtime SDK.
@@ -220,6 +305,16 @@ public class OtlpMetricReporter implements MetricsReporter {
             }
             this.jvmMetrics = null;
         }
+        ClientTelemetryForwarder ctf = this.clientTelemetryForwarder;
+        if (ctf != null) {
+            try {
+                ctf.stop();
+            } catch (Exception e) {
+                log.warn("Error stopping client telemetry forwarder", e);
+            }
+            this.clientTelemetryForwarder = null;
+        }
+        this.clientTelemetryReceiver = null;
         this.registry = null;
         this.yammerRegistry = null;
     }
@@ -257,6 +352,10 @@ public class OtlpMetricReporter implements MetricsReporter {
         JvmMetricsLifecycle jm = jvmMetrics;
         if (jm != null) {
             jm.rebuildIfRunning(resourceAttrs);
+        }
+        ClientTelemetryForwarder ctf = clientTelemetryForwarder;
+        if (ctf != null) {
+            ctf.setBrokerIdentity(contextLabels);
         }
     }
 

--- a/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporterConfig.java
+++ b/src/main/java/dev/monedula/metricsreporter/OtlpMetricReporterConfig.java
@@ -43,6 +43,21 @@ public class OtlpMetricReporterConfig {
     public static final String CLIENT_KEY_PATH = "otlp.metric.reporter.client.key.path";
     /** Whether to also export JVM runtime metrics. Default: {@code true}. */
     public static final String JVM_METRICS_ENABLED = "otlp.metric.reporter.jvm.metrics.enabled";
+    /** Kill-switch for KIP-714 client telemetry. When false, clientReceiver() returns null. Default: {@code true}. */
+    public static final String CLIENT_TELEMETRY_ENABLED = "otlp.metric.reporter.client.telemetry.enabled";
+    /** Add broker identity (cluster/node) to forwarded client metrics. Default: {@code true}. */
+    public static final String CLIENT_TELEMETRY_ENRICH_BROKER = "otlp.metric.reporter.client.telemetry.enrich.broker";
+    /** Add authenticated principal + client address to forwarded client metrics (PII/cardinality). Default: {@code false}. */
+    public static final String CLIENT_TELEMETRY_ENRICH_CLIENT_IDENTITY =
+            "otlp.metric.reporter.client.telemetry.enrich.client.identity";
+    /** Add client_id to forwarded client metrics as a resource attribute. Default: {@code true}. */
+    public static final String CLIENT_TELEMETRY_ENRICH_CLIENT_ID =
+            "otlp.metric.reporter.client.telemetry.enrich.client.id";
+    /** Add client_instance_id to forwarded client metrics as a resource attribute (opt-in). Default: {@code false}. */
+    public static final String CLIENT_TELEMETRY_ENRICH_CLIENT_INSTANCE_ID =
+            "otlp.metric.reporter.client.telemetry.enrich.client.instance.id";
+    /** Bounded in-memory queue size for inbound client pushes; overflow drops. Default: {@code 1024}. */
+    public static final String CLIENT_TELEMETRY_QUEUE_CAPACITY = "otlp.metric.reporter.client.telemetry.queue.capacity";
 
     public static final String TRANSPORT_GRPC = "grpc";
     public static final String TRANSPORT_HTTP = "http";
@@ -69,7 +84,13 @@ public class OtlpMetricReporterConfig {
             Map.entry(TRUSTED_CERTIFICATES_PATH, ""),
             Map.entry(CLIENT_CERTIFICATE_PATH, ""),
             Map.entry(CLIENT_KEY_PATH, ""),
-            Map.entry(JVM_METRICS_ENABLED, "true"));
+            Map.entry(JVM_METRICS_ENABLED, "true"),
+            Map.entry(CLIENT_TELEMETRY_ENABLED, "true"),
+            Map.entry(CLIENT_TELEMETRY_ENRICH_BROKER, "true"),
+            Map.entry(CLIENT_TELEMETRY_ENRICH_CLIENT_IDENTITY, "false"),
+            Map.entry(CLIENT_TELEMETRY_ENRICH_CLIENT_ID, "true"),
+            Map.entry(CLIENT_TELEMETRY_ENRICH_CLIENT_INSTANCE_ID, "false"),
+            Map.entry(CLIENT_TELEMETRY_QUEUE_CAPACITY, "1024"));
 
     /**
      * Canonical map of every configuration key this class understands to its default
@@ -97,6 +118,12 @@ public class OtlpMetricReporterConfig {
     private final String clientCertificatePath;
     private final String clientKeyPath;
     private final boolean jvmMetricsEnabled;
+    private final boolean clientTelemetryEnabled;
+    private final boolean clientTelemetryEnrichBroker;
+    private final boolean clientTelemetryEnrichClientIdentity;
+    private final boolean clientTelemetryEnrichClientId;
+    private final boolean clientTelemetryEnrichClientInstanceId;
+    private final int clientTelemetryQueueCapacity;
 
     public OtlpMetricReporterConfig(Map<String, ?> configs) {
         this.transport = getString(configs, TRANSPORT, TRANSPORT_GRPC);
@@ -116,6 +143,13 @@ public class OtlpMetricReporterConfig {
         this.clientCertificatePath = getOptionalString(configs, CLIENT_CERTIFICATE_PATH);
         this.clientKeyPath = getOptionalString(configs, CLIENT_KEY_PATH);
         this.jvmMetricsEnabled = getBoolean(configs, JVM_METRICS_ENABLED, true);
+        this.clientTelemetryEnabled = getBoolean(configs, CLIENT_TELEMETRY_ENABLED, true);
+        this.clientTelemetryEnrichBroker = getBoolean(configs, CLIENT_TELEMETRY_ENRICH_BROKER, true);
+        this.clientTelemetryEnrichClientIdentity = getBoolean(configs, CLIENT_TELEMETRY_ENRICH_CLIENT_IDENTITY, false);
+        this.clientTelemetryEnrichClientId = getBoolean(configs, CLIENT_TELEMETRY_ENRICH_CLIENT_ID, true);
+        this.clientTelemetryEnrichClientInstanceId =
+                getBoolean(configs, CLIENT_TELEMETRY_ENRICH_CLIENT_INSTANCE_ID, false);
+        this.clientTelemetryQueueCapacity = parseQueueCapacity(configs);
         validate(parsedEndpoint);
     }
 
@@ -249,6 +283,23 @@ public class OtlpMetricReporterConfig {
         return Collections.unmodifiableMap(result);
     }
 
+    /**
+     * Parse and bounds-check the client-telemetry queue capacity on the full {@code long} BEFORE
+     * narrowing to {@code int}: a value past {@link Integer#MAX_VALUE} would otherwise wrap in the
+     * cast — either slipping past a post-cast positivity check as a small bogus capacity, or
+     * demanding a multi-GB eager {@code ArrayBlockingQueue} allocation whose
+     * {@code OutOfMemoryError} (an {@code Error}) the fail-open catch in OtlpMetricReporter
+     * cannot swallow.
+     */
+    private static int parseQueueCapacity(Map<String, ?> cfg) {
+        long capacity = getLong(cfg, CLIENT_TELEMETRY_QUEUE_CAPACITY, 1024L);
+        if (capacity <= 0 || capacity > Integer.MAX_VALUE) {
+            throw new ConfigException(
+                    CLIENT_TELEMETRY_QUEUE_CAPACITY, capacity, "must be between 1 and " + Integer.MAX_VALUE);
+        }
+        return (int) capacity;
+    }
+
     private static String parseCompression(String raw) {
         String normalized = raw.trim().toLowerCase(Locale.ROOT);
         if (!SUPPORTED_COMPRESSION.contains(normalized)) {
@@ -304,5 +355,29 @@ public class OtlpMetricReporterConfig {
 
     public boolean jvmMetricsEnabled() {
         return jvmMetricsEnabled;
+    }
+
+    public boolean clientTelemetryEnabled() {
+        return clientTelemetryEnabled;
+    }
+
+    public boolean clientTelemetryEnrichBroker() {
+        return clientTelemetryEnrichBroker;
+    }
+
+    public boolean clientTelemetryEnrichClientIdentity() {
+        return clientTelemetryEnrichClientIdentity;
+    }
+
+    public boolean clientTelemetryEnrichClientId() {
+        return clientTelemetryEnrichClientId;
+    }
+
+    public boolean clientTelemetryEnrichClientInstanceId() {
+        return clientTelemetryEnrichClientInstanceId;
+    }
+
+    public int clientTelemetryQueueCapacity() {
+        return clientTelemetryQueueCapacity;
     }
 }

--- a/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsConverter.java
+++ b/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsConverter.java
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher.ClientIdentity;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converts a serialized OTLP {@code MetricsData} payload (pushed by a KIP-714 client) into
+ * OTel SDK {@link MetricData} so it can be exported through the reporter's existing
+ * {@code MetricExporter}. Each produced metric carries an enriched {@link Resource}.
+ *
+ * <p>Supported data-point families: gauge, sum, histogram (long or double). Any other type
+ * is skipped and counted in {@link ConversionResult#unsupportedDropped()} — see the spec's
+ * fidelity boundary.
+ */
+public final class ClientMetricsConverter {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientMetricsConverter.class);
+
+    /** Result of a conversion: the produced metrics plus the count of dropped unsupported data points. */
+    public record ConversionResult(List<MetricData> metrics, int unsupportedDropped) {}
+
+    /** One converted metric ({@code data} null when the whole metric was unsupported/empty) plus per-point drops. */
+    private record Converted(MetricData data, int droppedPoints) {
+        static final Converted UNSUPPORTED = new Converted(null, 0);
+    }
+
+    /** Data points whose ValueCase matches the metric's first point, plus the count that didn't. */
+    private record PartitionedPoints(List<NumberDataPoint> matching, int mismatched, boolean isLong) {}
+
+    private final ClientMetricsEnricher enricher;
+
+    public ClientMetricsConverter(ClientMetricsEnricher enricher) {
+        this.enricher = enricher;
+    }
+
+    public ConversionResult convert(byte[] payload, Map<String, String> brokerIdentity, ClientIdentity clientIdentity)
+            throws InvalidProtocolBufferException {
+        MetricsData data = MetricsData.parseFrom(payload);
+        List<MetricData> out = new ArrayList<>();
+        int unsupported = 0;
+        for (ResourceMetrics rm : data.getResourceMetricsList()) {
+            Resource resource = enricher.enrich(rm.getResource(), brokerIdentity, clientIdentity);
+            for (ScopeMetrics sm : rm.getScopeMetricsList()) {
+                InstrumentationScopeInfo scope = scopeOf(sm);
+                for (Metric m : sm.getMetricsList()) {
+                    Converted converted = convertMetric(resource, scope, m);
+                    unsupported += converted.droppedPoints();
+                    if (converted.data() == null) {
+                        unsupported++;
+                    } else {
+                        out.add(converted.data());
+                    }
+                }
+            }
+        }
+        return new ConversionResult(out, unsupported);
+    }
+
+    private Converted convertMetric(Resource resource, InstrumentationScopeInfo scope, Metric m) {
+        Converted converted =
+                switch (m.getDataCase()) {
+                    case GAUGE -> gauge(resource, scope, m);
+                    case SUM -> sum(resource, scope, m);
+                    case HISTOGRAM -> new Converted(histogram(resource, scope, m), 0);
+                    default -> Converted.UNSUPPORTED;
+                };
+        if (converted.data() == null) {
+            log.debug("Dropping unsupported client metric '{}' (data case {})", m.getName(), m.getDataCase());
+        }
+        return converted;
+    }
+
+    private Converted gauge(Resource resource, InstrumentationScopeInfo scope, Metric m) {
+        List<NumberDataPoint> points = m.getGauge().getDataPointsList();
+        if (points.isEmpty()) {
+            return Converted.UNSUPPORTED;
+        }
+        PartitionedPoints pp = partitionByFirstValueCase(points, m.getName());
+        MetricData data = pp.isLong()
+                ? ImmutableMetricData.createLongGauge(
+                        resource,
+                        scope,
+                        m.getName(),
+                        m.getDescription(),
+                        m.getUnit(),
+                        ImmutableGaugeData.create(buildLongPoints(pp.matching())))
+                : ImmutableMetricData.createDoubleGauge(
+                        resource,
+                        scope,
+                        m.getName(),
+                        m.getDescription(),
+                        m.getUnit(),
+                        ImmutableGaugeData.create(buildDoublePoints(pp.matching())));
+        return new Converted(data, pp.mismatched());
+    }
+
+    private Converted sum(Resource resource, InstrumentationScopeInfo scope, Metric m) {
+        io.opentelemetry.proto.metrics.v1.Sum s = m.getSum();
+        List<NumberDataPoint> points = s.getDataPointsList();
+        if (points.isEmpty()) {
+            return Converted.UNSUPPORTED;
+        }
+        boolean monotonic = s.getIsMonotonic();
+        AggregationTemporality temporality = temporalityOf(s.getAggregationTemporality());
+        PartitionedPoints pp = partitionByFirstValueCase(points, m.getName());
+        MetricData data = pp.isLong()
+                ? ImmutableMetricData.createLongSum(
+                        resource,
+                        scope,
+                        m.getName(),
+                        m.getDescription(),
+                        m.getUnit(),
+                        ImmutableSumData.create(monotonic, temporality, buildLongPoints(pp.matching())))
+                : ImmutableMetricData.createDoubleSum(
+                        resource,
+                        scope,
+                        m.getName(),
+                        m.getDescription(),
+                        m.getUnit(),
+                        ImmutableSumData.create(monotonic, temporality, buildDoublePoints(pp.matching())));
+        return new Converted(data, pp.mismatched());
+    }
+
+    /**
+     * Split a metric's number points by whether their ValueCase matches the first point's. The
+     * OTLP spec requires one consistent value type per metric, but this payload is untrusted
+     * network input and protobuf's oneof does not enforce the rule on the wire — reading a point
+     * through the wrong accessor silently yields 0, which would export corrupted zero values.
+     * Mismatched points are dropped and counted in {@link ConversionResult#unsupportedDropped()}
+     * instead. The first point always matches, so {@code matching} is never empty.
+     */
+    private static PartitionedPoints partitionByFirstValueCase(List<NumberDataPoint> points, String metricName) {
+        NumberDataPoint.ValueCase expected = points.get(0).getValueCase();
+        List<NumberDataPoint> matching = new ArrayList<>(points.size());
+        int mismatched = 0;
+        for (NumberDataPoint p : points) {
+            if (p.getValueCase() == expected) {
+                matching.add(p);
+            } else {
+                mismatched++;
+            }
+        }
+        if (mismatched > 0) {
+            log.debug(
+                    "Dropping {} data point(s) of client metric '{}' whose value type differs from the first point ({})",
+                    mismatched,
+                    metricName,
+                    expected);
+        }
+        return new PartitionedPoints(matching, mismatched, expected == NumberDataPoint.ValueCase.AS_INT);
+    }
+
+    private static List<io.opentelemetry.sdk.metrics.data.LongPointData> buildLongPoints(List<NumberDataPoint> points) {
+        var pd = new ArrayList<io.opentelemetry.sdk.metrics.data.LongPointData>(points.size());
+        for (NumberDataPoint p : points) {
+            pd.add(ImmutableLongPointData.create(
+                    p.getStartTimeUnixNano(), p.getTimeUnixNano(), attributesOf(p.getAttributesList()), p.getAsInt()));
+        }
+        return pd;
+    }
+
+    private static List<io.opentelemetry.sdk.metrics.data.DoublePointData> buildDoublePoints(
+            List<NumberDataPoint> points) {
+        var pd = new ArrayList<io.opentelemetry.sdk.metrics.data.DoublePointData>(points.size());
+        for (NumberDataPoint p : points) {
+            pd.add(ImmutableDoublePointData.create(
+                    p.getStartTimeUnixNano(),
+                    p.getTimeUnixNano(),
+                    attributesOf(p.getAttributesList()),
+                    p.getAsDouble()));
+        }
+        return pd;
+    }
+
+    private MetricData histogram(Resource resource, InstrumentationScopeInfo scope, Metric m) {
+        io.opentelemetry.proto.metrics.v1.Histogram h = m.getHistogram();
+        var points = h.getDataPointsList();
+        if (points.isEmpty()) {
+            return null;
+        }
+        AggregationTemporality temporality = temporalityOf(h.getAggregationTemporality());
+        List<HistogramPointData> pd = new ArrayList<>(points.size());
+        for (io.opentelemetry.proto.metrics.v1.HistogramDataPoint p : points) {
+            pd.add(ImmutableHistogramPointData.create(
+                    p.getStartTimeUnixNano(),
+                    p.getTimeUnixNano(),
+                    attributesOf(p.getAttributesList()),
+                    p.getSum(),
+                    p.hasMin(),
+                    p.hasMin() ? p.getMin() : 0.0,
+                    p.hasMax(),
+                    p.hasMax() ? p.getMax() : 0.0,
+                    p.getExplicitBoundsList(),
+                    p.getBucketCountsList()));
+        }
+        return ImmutableMetricData.createDoubleHistogram(
+                resource,
+                scope,
+                m.getName(),
+                m.getDescription(),
+                m.getUnit(),
+                ImmutableHistogramData.create(temporality, pd));
+    }
+
+    private static AggregationTemporality temporalityOf(io.opentelemetry.proto.metrics.v1.AggregationTemporality t) {
+        return t == io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA
+                ? AggregationTemporality.DELTA
+                : AggregationTemporality.CUMULATIVE;
+    }
+
+    private static InstrumentationScopeInfo scopeOf(ScopeMetrics sm) {
+        String name = sm.getScope().getName();
+        String version = sm.getScope().getVersion();
+        if (version.isEmpty()) {
+            return InstrumentationScopeInfo.create(name.isEmpty() ? "kafka-client" : name);
+        }
+        return InstrumentationScopeInfo.builder(name.isEmpty() ? "kafka-client" : name)
+                .setVersion(version)
+                .build();
+    }
+
+    static Attributes attributesOf(List<KeyValue> kvs) {
+        AttributesBuilder b = Attributes.builder();
+        for (KeyValue kv : kvs) {
+            b.put(
+                    io.opentelemetry.api.common.AttributeKey.stringKey(kv.getKey()),
+                    ClientMetricsEnricher.stringify(kv.getValue()));
+        }
+        return b.build();
+    }
+}

--- a/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsEnricher.java
+++ b/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsEnricher.java
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Builds the OTLP {@link Resource} attached to forwarded KIP-714 client metrics.
+ *
+ * <p>Merge order (later wins): the client's own payload resource attributes, then broker
+ * identity (so a client cannot spoof {@code kafka.cluster.id}), then optional client
+ * identity. Each enrichment layer is gated by a config toggle.
+ */
+public final class ClientMetricsEnricher {
+
+    /** Authenticated principal and source address of the pushing client (from the request context). */
+    public record ClientIdentity(String principal, String address, String clientId, String clientInstanceId) {}
+
+    private final boolean enrichBroker;
+    private final boolean enrichClientIdentity;
+    private final boolean enrichClientId;
+    private final boolean enrichClientInstanceId;
+
+    public ClientMetricsEnricher(
+            boolean enrichBroker,
+            boolean enrichClientIdentity,
+            boolean enrichClientId,
+            boolean enrichClientInstanceId) {
+        this.enrichBroker = enrichBroker;
+        this.enrichClientIdentity = enrichClientIdentity;
+        this.enrichClientId = enrichClientId;
+        this.enrichClientInstanceId = enrichClientInstanceId;
+    }
+
+    public Resource enrich(
+            io.opentelemetry.proto.resource.v1.Resource clientResource,
+            Map<String, String> brokerIdentity,
+            ClientIdentity clientIdentity) {
+        Map<String, String> merged = new LinkedHashMap<>();
+        for (KeyValue kv : clientResource.getAttributesList()) {
+            merged.put(kv.getKey(), stringify(kv.getValue()));
+        }
+        if (enrichBroker) {
+            merged.putAll(brokerIdentity);
+        }
+        if (enrichClientIdentity && clientIdentity != null) {
+            merged.put("kafka.client.principal", clientIdentity.principal());
+            merged.put("kafka.client.address", clientIdentity.address());
+        }
+        if (enrichClientId && clientIdentity != null) {
+            String clientId = clientIdentity.clientId();
+            if (clientId != null && !clientId.isBlank()) {
+                merged.put("client_id", clientId);
+            }
+        }
+        if (enrichClientInstanceId && clientIdentity != null) {
+            String clientInstanceId = clientIdentity.clientInstanceId();
+            if (clientInstanceId != null && !clientInstanceId.isBlank()) {
+                merged.put("client_instance_id", clientInstanceId);
+            }
+        }
+        AttributesBuilder b = Attributes.builder();
+        merged.forEach((k, v) -> b.put(stringKey(k), v));
+        return Resource.create(b.build());
+    }
+
+    /**
+     * Render an OTLP AnyValue as a string label. Scalar types are stringified; composite types
+     * (array, kvlist, bytes) and unset values produce an empty string — safe as a metric label,
+     * though the key then appears with no value.
+     */
+    static String stringify(AnyValue v) {
+        return switch (v.getValueCase()) {
+            case STRING_VALUE -> v.getStringValue();
+            case BOOL_VALUE -> Boolean.toString(v.getBoolValue());
+            case INT_VALUE -> Long.toString(v.getIntValue());
+            case DOUBLE_VALUE -> Double.toString(v.getDoubleValue());
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryForwarder.java
+++ b/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryForwarder.java
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsConverter.ConversionResult;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher.ClientIdentity;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drains inbound KIP-714 client telemetry off a bounded queue on a single daemon thread,
+ * converts each payload to SDK {@link MetricData}, and exports it through its own
+ * {@link MetricExporter} (built from the reporter config, isolated from the broker-metrics
+ * collector). Honors the reporter's prime invariant: the request-handler thread only does
+ * a non-blocking {@link #submit}; all parsing and I/O happen here. Failures drop the batch
+ * and increment counters — nothing retries.
+ *
+ * <p>Counter granularity: {@code received}, {@code forwarded}, and {@code dropped} are
+ * per-payload (one inbound telemetry push = one unit). {@code unsupportedMetricsDropped}
+ * is per-metric: it counts individual metrics within a payload that the converter could
+ * not represent, without marking the whole payload as dropped.
+ */
+public final class ClientTelemetryForwarder {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientTelemetryForwarder.class);
+
+    /** One unit of inbound work: the copied payload bytes and the (optional) pushing client's identity. */
+    private record Item(byte[] payload, ClientIdentity clientIdentity) {}
+
+    private static final Item POISON = new Item(new byte[0], null);
+
+    private final MetricExporter exporter;
+    private final ClientMetricsConverter converter;
+    private final BlockingQueue<Item> queue;
+    private final long timeoutMs;
+
+    private final LongAdder received = new LongAdder();
+    private final LongAdder forwarded = new LongAdder();
+    private final LongAdder dropped = new LongAdder();
+    private final LongAdder unsupportedMetricsDropped = new LongAdder();
+
+    private volatile Map<String, String> brokerIdentity = Map.of();
+    private volatile Thread worker;
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    public ClientTelemetryForwarder(
+            MetricExporter exporter, ClientMetricsConverter converter, int queueCapacity, long timeoutMs) {
+        this.exporter = exporter;
+        this.converter = converter;
+        this.queue = new ArrayBlockingQueue<>(queueCapacity);
+        this.timeoutMs = timeoutMs;
+    }
+
+    /** Latest broker identity labels (cluster/node); updated on contextChange. */
+    public void setBrokerIdentity(Map<String, String> brokerIdentity) {
+        this.brokerIdentity = Map.copyOf(brokerIdentity);
+    }
+
+    /** Current broker-identity labels applied to forwarded client metrics. Visible for tests/observability. */
+    public Map<String, String> currentBrokerIdentity() {
+        return brokerIdentity;
+    }
+
+    public void start() {
+        if (this.worker != null) {
+            return;
+        }
+        Thread t = new Thread(this::run, "monedula-client-telemetry");
+        t.setDaemon(true);
+        t.setUncaughtExceptionHandler((th, ex) -> log.error("Uncaught exception in client telemetry thread", ex));
+        this.worker = t;
+        t.start();
+    }
+
+    /**
+     * Enqueue a copied payload. Returns false (and counts a drop) when the queue is full or the
+     * forwarder has been stopped — never blocks the calling broker request-handler thread.
+     */
+    public boolean submit(byte[] payload, ClientIdentity clientIdentity) {
+        received.increment();
+        if (stopped.get()) {
+            // The drain thread is gone; an offer would park the payload invisibly on a dead
+            // queue (neither forwarded nor counted) until it fills. Count the drop right away.
+            dropped.increment();
+            return false;
+        }
+        if (queue.offer(new Item(payload, clientIdentity))) {
+            return true;
+        }
+        dropped.increment();
+        return false;
+    }
+
+    private void run() {
+        try {
+            while (true) {
+                Item item = queue.take();
+                if (item == POISON) return;
+                process(item);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void process(Item item) {
+        try {
+            ConversionResult result = converter.convert(item.payload(), brokerIdentity, item.clientIdentity());
+            if (result.unsupportedDropped() > 0) {
+                unsupportedMetricsDropped.add(result.unsupportedDropped());
+            }
+            List<MetricData> metrics = result.metrics();
+            if (metrics.isEmpty()) {
+                return;
+            }
+            var export = exporter.export(metrics);
+            export.join(timeoutMs, TimeUnit.MILLISECONDS);
+            if (export.isSuccess()) {
+                forwarded.increment();
+            } else {
+                dropped.increment();
+                log.warn("Client telemetry export failed or timed out — dropping batch");
+            }
+        } catch (Throwable t) {
+            dropped.increment();
+            log.warn("Error forwarding client telemetry — dropping batch", t);
+        }
+    }
+
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return; // already stopped — idempotent
+        }
+        Thread t = this.worker;
+        if (t != null) {
+            // The drain thread exits either by consuming POISON or, if the queue is full
+            // so the offer fails, via the interrupt below (queue.take() throws InterruptedException).
+            if (!queue.offer(POISON)) {
+                log.debug("Client telemetry queue full at shutdown — relying on interrupt to stop the drain thread");
+            }
+            t.interrupt();
+            try {
+                t.join(timeoutMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        // Always release the exporter, even if start() was never called (e.g. start() threw).
+        exporter.shutdown().join(timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    public long receivedCount() {
+        return received.sum();
+    }
+
+    public long forwardedCount() {
+        return forwarded.sum();
+    }
+
+    public long droppedCount() {
+        return dropped.sum();
+    }
+
+    public long unsupportedMetricsDroppedCount() {
+        return unsupportedMetricsDropped.sum();
+    }
+
+    public int queueDepth() {
+        return queue.size();
+    }
+}

--- a/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryReceiverImpl.java
+++ b/src/main/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryReceiverImpl.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher.ClientIdentity;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.telemetry.ClientTelemetryPayload;
+import org.apache.kafka.server.telemetry.ClientTelemetryReceiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * KIP-714 receiver. Kafka invokes {@link #exportMetrics} on a broker request-handler thread
+ * for each client push. This method must stay cheap: copy the payload bytes (the buffer is
+ * not valid after return), optionally capture the client's identity, and hand off to the
+ * forwarder's non-blocking submit. No parsing, no I/O here.
+ */
+public final class ClientTelemetryReceiverImpl implements ClientTelemetryReceiver {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientTelemetryReceiverImpl.class);
+
+    /** Seam over {@link ClientTelemetryForwarder#submit} so the receiver is unit-testable in isolation. */
+    public interface Submitter {
+        boolean submit(byte[] payload, ClientIdentity clientIdentity);
+    }
+
+    private final Submitter submitter;
+    private final boolean captureClientIdentity;
+
+    public ClientTelemetryReceiverImpl(Submitter submitter, boolean captureClientIdentity) {
+        this.submitter = submitter;
+        this.captureClientIdentity = captureClientIdentity;
+    }
+
+    @Override
+    public void exportMetrics(AuthorizableRequestContext context, ClientTelemetryPayload payload) {
+        try {
+            ByteBuffer data = payload == null ? null : payload.data();
+            if (data == null || !data.hasRemaining()) {
+                return;
+            }
+            byte[] copy = new byte[data.remaining()];
+            data.duplicate().get(copy);
+
+            String clientId = context == null ? null : context.clientId();
+            org.apache.kafka.common.Uuid instanceId = payload.clientInstanceId();
+            String clientInstanceId = instanceId == null ? null : instanceId.toString();
+
+            String principal = null;
+            String address = null;
+            if (captureClientIdentity && context != null) {
+                principal =
+                        context.principal() == null ? "" : context.principal().toString();
+                InetAddress addr = context.clientAddress();
+                address = addr == null ? "" : addr.getHostAddress();
+            }
+            ClientIdentity identity = new ClientIdentity(principal, address, clientId, clientInstanceId);
+            submitter.submit(copy, identity);
+        } catch (Throwable t) {
+            // Never let a telemetry hiccup disturb the broker request path.
+            if (t instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.debug("Failed to accept client telemetry payload — ignoring", t);
+        }
+    }
+}

--- a/src/test/java/dev/monedula/metricsreporter/MetricCollectorTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/MetricCollectorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
 import java.util.List;
@@ -174,5 +175,44 @@ class MetricCollectorTest {
                 collector.exportFailureCount() >= 3,
                 "failure count was " + collector.exportFailureCount() + ", expected >= 3");
         assertEquals(0, collector.exportSuccessCount(), "no successes expected, got " + collector.exportSuccessCount());
+    }
+
+    @Test
+    void emits_client_telemetry_self_metrics_when_counters_present() {
+        ArgumentCaptor<Collection<MetricData>> batch = ArgumentCaptor.forClass(Collection.class);
+        MetricExporter exporter = Mockito.mock(MetricExporter.class);
+        when(exporter.export(batch.capture())).thenReturn(CompletableResultCode.ofSuccess());
+        when(exporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+        // long interval so the scheduler won't fire on its own; we drive a single tick via exportOnceForTest()
+        MetricCollector collector = new MetricCollector(
+                new MetricRegistry(List.of()), new MetricDataMapper(Map.of()), exporter, 60_000L, 1_000L);
+        // Distinct value per counter so a transposed name-to-counter mapping fails the assertions below.
+        collector.setClientTelemetryCounters(() -> new MetricCollector.ClientTelemetryCounters(7L, 5L, 2L, 1L, 3L));
+        try {
+            collector.exportOnceForTest();
+            Collection<MetricData> metrics = batch.getValue();
+            assertEquals(7.0, selfMetricValue(metrics, "monedula_reporter_clienttelemetry_received_total"));
+            assertEquals(5.0, selfMetricValue(metrics, "monedula_reporter_clienttelemetry_forwarded_total"));
+            assertEquals(2.0, selfMetricValue(metrics, "monedula_reporter_clienttelemetry_dropped_total"));
+            assertEquals(
+                    1.0,
+                    selfMetricValue(metrics, "monedula_reporter_clienttelemetry_unsupported_metrics_dropped_total"));
+            assertEquals(3.0, selfMetricValue(metrics, "monedula_reporter_clienttelemetry_queue_depth"));
+        } finally {
+            collector.stop();
+        }
+    }
+
+    /** Value of the single data point of the named self-metric (sum or gauge) in the exported batch. */
+    private static double selfMetricValue(Collection<MetricData> batch, String name) {
+        MetricData md = batch.stream()
+                .filter(m -> m.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("metric not exported: " + name));
+        var points = md.getType() == MetricDataType.DOUBLE_SUM
+                ? md.getDoubleSumData().getPoints()
+                : md.getDoubleGaugeData().getPoints();
+        return points.iterator().next().getValue();
     }
 }

--- a/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterConfigTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterConfigTest.java
@@ -60,6 +60,17 @@ class OtlpMetricReporterConfigTest {
         assertTrue(OtlpMetricReporterConfig.defaults().containsKey(OtlpMetricReporterConfig.CLIENT_CERTIFICATE_PATH));
         assertTrue(OtlpMetricReporterConfig.defaults().containsKey(OtlpMetricReporterConfig.CLIENT_KEY_PATH));
         assertTrue(OtlpMetricReporterConfig.defaults().containsKey(OtlpMetricReporterConfig.JVM_METRICS_ENABLED));
+        assertTrue(OtlpMetricReporterConfig.defaults().containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENABLED));
+        assertTrue(OtlpMetricReporterConfig.defaults()
+                .containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_BROKER));
+        assertTrue(OtlpMetricReporterConfig.defaults()
+                .containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_IDENTITY));
+        assertTrue(OtlpMetricReporterConfig.defaults()
+                .containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_ID));
+        assertTrue(OtlpMetricReporterConfig.defaults()
+                .containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_INSTANCE_ID));
+        assertTrue(OtlpMetricReporterConfig.defaults()
+                .containsKey(OtlpMetricReporterConfig.CLIENT_TELEMETRY_QUEUE_CAPACITY));
     }
 
     @Test
@@ -267,5 +278,71 @@ class OtlpMetricReporterConfigTest {
                 .jvmMetricsEnabled());
         assertFalse(new OtlpMetricReporterConfig(Map.of("otlp.metric.reporter.jvm.metrics.enabled", "False"))
                 .jvmMetricsEnabled());
+    }
+
+    @Test
+    void client_telemetry_defaults() {
+        var cfg = new OtlpMetricReporterConfig(Map.of());
+        assertTrue(cfg.clientTelemetryEnabled());
+        assertTrue(cfg.clientTelemetryEnrichBroker());
+        assertFalse(cfg.clientTelemetryEnrichClientIdentity());
+        assertEquals(1024, cfg.clientTelemetryQueueCapacity());
+    }
+
+    @Test
+    void client_telemetry_overrides() {
+        var cfg = new OtlpMetricReporterConfig(Map.of(
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENABLED, "false",
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_BROKER, "false",
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_IDENTITY, "true",
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_QUEUE_CAPACITY, "8"));
+        assertFalse(cfg.clientTelemetryEnabled());
+        assertFalse(cfg.clientTelemetryEnrichBroker());
+        assertTrue(cfg.clientTelemetryEnrichClientIdentity());
+        assertEquals(8, cfg.clientTelemetryQueueCapacity());
+    }
+
+    @Test
+    void client_telemetry_queue_capacity_must_be_positive() {
+        assertThrows(
+                ConfigException.class,
+                () -> new OtlpMetricReporterConfig(
+                        Map.of(OtlpMetricReporterConfig.CLIENT_TELEMETRY_QUEUE_CAPACITY, "0")));
+    }
+
+    @Test
+    void client_telemetry_queue_capacity_rejects_values_past_integer_range() {
+        // 2^32+5 would wrap to 5 in a naive long->int cast and silently pass a post-cast
+        // positivity check; the bounds check must run on the full long instead.
+        assertThrows(
+                ConfigException.class,
+                () -> new OtlpMetricReporterConfig(
+                        Map.of(OtlpMetricReporterConfig.CLIENT_TELEMETRY_QUEUE_CAPACITY, "4294967301")));
+        // Just past Integer.MAX_VALUE: would otherwise demand a multi-GB eager queue allocation.
+        assertThrows(
+                ConfigException.class,
+                () -> new OtlpMetricReporterConfig(
+                        Map.of(OtlpMetricReporterConfig.CLIENT_TELEMETRY_QUEUE_CAPACITY, "2147483648")));
+    }
+
+    @Test
+    void client_telemetry_enrich_client_id_defaults_to_true() {
+        var cfg = new OtlpMetricReporterConfig(Map.of());
+        assertTrue(cfg.clientTelemetryEnrichClientId());
+    }
+
+    @Test
+    void client_telemetry_enrich_client_instance_id_defaults_to_false() {
+        var cfg = new OtlpMetricReporterConfig(Map.of());
+        assertFalse(cfg.clientTelemetryEnrichClientInstanceId());
+    }
+
+    @Test
+    void client_telemetry_enrich_client_id_and_instance_id_can_be_overridden() {
+        var cfg = new OtlpMetricReporterConfig(Map.of(
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_ID, "false",
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENRICH_CLIENT_INSTANCE_ID, "true"));
+        assertFalse(cfg.clientTelemetryEnrichClientId());
+        assertTrue(cfg.clientTelemetryEnrichClientInstanceId());
     }
 }

--- a/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/OtlpMetricReporterTest.java
@@ -280,6 +280,75 @@ class OtlpMetricReporterTest {
     }
 
     @Test
+    void client_receiver_returned_when_enabled() {
+        var reporter = new OtlpMetricReporter();
+        reporter.configure(Map.of(
+                OtlpMetricReporterConfig.ENDPOINT, "http://localhost:4317",
+                OtlpMetricReporterConfig.INTERVAL_MS, "60000",
+                OtlpMetricReporterConfig.TIMEOUT_MS, "1000"));
+        try {
+            // Typed assignment (not instanceof): removing `implements ClientTelemetry` from the
+            // reporter would fail this line at compile time rather than at runtime.
+            org.apache.kafka.server.telemetry.ClientTelemetry telemetry = reporter;
+            assertNotNull(telemetry.clientReceiver());
+        } finally {
+            reporter.close();
+        }
+    }
+
+    @Test
+    void client_receiver_null_when_disabled() {
+        var reporter = new OtlpMetricReporter();
+        reporter.configure(Map.of(
+                OtlpMetricReporterConfig.ENDPOINT, "http://localhost:4317",
+                OtlpMetricReporterConfig.INTERVAL_MS, "60000",
+                OtlpMetricReporterConfig.TIMEOUT_MS, "1000",
+                OtlpMetricReporterConfig.CLIENT_TELEMETRY_ENABLED, "false"));
+        try {
+            org.apache.kafka.server.telemetry.ClientTelemetry telemetry = reporter;
+            assertNull(telemetry.clientReceiver());
+        } finally {
+            reporter.close();
+        }
+    }
+
+    @Test
+    void client_receiver_null_when_noop() {
+        var reporter = new OtlpMetricReporter();
+        // Invalid config (timeout >= interval) forces no-op mode.
+        reporter.configure(Map.of(
+                OtlpMetricReporterConfig.INTERVAL_MS, "1000",
+                OtlpMetricReporterConfig.TIMEOUT_MS, "1000"));
+        try {
+            org.apache.kafka.server.telemetry.ClientTelemetry telemetry = reporter;
+            assertNull(telemetry.clientReceiver());
+        } finally {
+            reporter.close();
+        }
+    }
+
+    @Test
+    void context_change_refreshes_client_telemetry_broker_identity() {
+        var reporter = new OtlpMetricReporter();
+        reporter.configure(Map.of(
+                OtlpMetricReporterConfig.ENDPOINT, "http://localhost:4317",
+                OtlpMetricReporterConfig.INTERVAL_MS, "60000",
+                OtlpMetricReporterConfig.TIMEOUT_MS, "1000"));
+        try {
+            reporter.contextChange(
+                    new KafkaMetricsContext("kafka.server", Map.of("kafka.cluster.id", "CID", "kafka.node.id", "3")));
+            assertEquals(
+                    "CID",
+                    reporter.clientTelemetryForwarder.currentBrokerIdentity().get("kafka.cluster.id"));
+            assertEquals(
+                    "3",
+                    reporter.clientTelemetryForwarder.currentBrokerIdentity().get("kafka.node.id"));
+        } finally {
+            reporter.close();
+        }
+    }
+
+    @Test
     void context_change_after_configure_rebuilds_jvm_metrics_resource_labels() {
         OtlpMetricReporter reporter = new OtlpMetricReporter();
         reporter.configure(Map.of(

--- a/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsConverterTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsConverterTest.java
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.metrics.v1.Gauge;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ClientMetricsConverterTest {
+
+    // stateless converter; safe to share across tests
+    static final ClientMetricsConverter CONVERTER =
+            new ClientMetricsConverter(new ClientMetricsEnricher(false, false, false, false));
+
+    static MetricsData oneMetric(Metric metric) {
+        return MetricsData.newBuilder()
+                .addResourceMetrics(ResourceMetrics.newBuilder()
+                        .addScopeMetrics(ScopeMetrics.newBuilder()
+                                .setScope(InstrumentationScope.newBuilder()
+                                        .setName("client")
+                                        .build())
+                                .addMetrics(metric)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Test
+    void converts_double_gauge() throws Exception {
+        Metric m = Metric.newBuilder()
+                .setName("client.connection.count")
+                .setGauge(Gauge.newBuilder()
+                        .addDataPoints(NumberDataPoint.newBuilder()
+                                .setTimeUnixNano(123L)
+                                .setAsDouble(4.0)
+                                .build())
+                        .build())
+                .build();
+
+        var result = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null);
+        assertEquals(0, result.unsupportedDropped());
+        List<MetricData> data = result.metrics();
+        assertEquals(1, data.size());
+        assertEquals("client.connection.count", data.get(0).getName());
+        assertEquals(MetricDataType.DOUBLE_GAUGE, data.get(0).getType());
+        assertEquals(
+                4.0,
+                data.get(0).getDoubleGaugeData().getPoints().iterator().next().getValue());
+    }
+
+    @Test
+    void converts_long_gauge() throws Exception {
+        Metric m = Metric.newBuilder()
+                .setName("client.assigned.partitions")
+                .setGauge(Gauge.newBuilder()
+                        .addDataPoints(NumberDataPoint.newBuilder()
+                                .setTimeUnixNano(9L)
+                                .setAsInt(7L)
+                                .build())
+                        .build())
+                .build();
+
+        var data = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null).metrics();
+        assertEquals(MetricDataType.LONG_GAUGE, data.get(0).getType());
+        assertEquals(
+                7L, data.get(0).getLongGaugeData().getPoints().iterator().next().getValue());
+    }
+
+    @Test
+    void converts_monotonic_cumulative_double_sum_preserving_timestamps() throws Exception {
+        io.opentelemetry.proto.metrics.v1.Sum sum = io.opentelemetry.proto.metrics.v1.Sum.newBuilder()
+                .setIsMonotonic(true)
+                .setAggregationTemporality(
+                        io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE)
+                .addDataPoints(NumberDataPoint.newBuilder()
+                        .setStartTimeUnixNano(100L)
+                        .setTimeUnixNano(200L)
+                        .setAsDouble(42.0)
+                        .build())
+                .build();
+        Metric m = Metric.newBuilder().setName("client.bytes.sent").setSum(sum).build();
+
+        var data = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null).metrics();
+        assertEquals(MetricDataType.DOUBLE_SUM, data.get(0).getType());
+        var sd = data.get(0).getDoubleSumData();
+        assertTrue(sd.isMonotonic());
+        assertEquals(AggregationTemporality.CUMULATIVE, sd.getAggregationTemporality());
+        var point = sd.getPoints().iterator().next();
+        assertEquals(100L, point.getStartEpochNanos());
+        assertEquals(200L, point.getEpochNanos());
+        assertEquals(42.0, point.getValue());
+    }
+
+    @Test
+    void converts_delta_long_sum() throws Exception {
+        io.opentelemetry.proto.metrics.v1.Sum sum = io.opentelemetry.proto.metrics.v1.Sum.newBuilder()
+                .setIsMonotonic(false)
+                .setAggregationTemporality(
+                        io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA)
+                .addDataPoints(NumberDataPoint.newBuilder()
+                        .setTimeUnixNano(5L)
+                        .setAsInt(3L)
+                        .build())
+                .build();
+        Metric m = Metric.newBuilder().setName("client.errors").setSum(sum).build();
+
+        var sd = CONVERTER
+                .convert(oneMetric(m).toByteArray(), Map.of(), null)
+                .metrics()
+                .get(0)
+                .getLongSumData();
+        assertFalse(sd.isMonotonic());
+        assertEquals(AggregationTemporality.DELTA, sd.getAggregationTemporality());
+        assertEquals(3L, sd.getPoints().iterator().next().getValue());
+    }
+
+    @Test
+    void converts_cumulative_histogram() throws Exception {
+        io.opentelemetry.proto.metrics.v1.Histogram h = io.opentelemetry.proto.metrics.v1.Histogram.newBuilder()
+                .setAggregationTemporality(
+                        io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE)
+                .addDataPoints(io.opentelemetry.proto.metrics.v1.HistogramDataPoint.newBuilder()
+                        .setStartTimeUnixNano(1L)
+                        .setTimeUnixNano(2L)
+                        .setCount(3L)
+                        .setSum(30.0)
+                        .setMin(5.0)
+                        .setMax(20.0)
+                        .addExplicitBounds(10.0)
+                        .addBucketCounts(1L)
+                        .addBucketCounts(2L)
+                        .build())
+                .build();
+        Metric m = Metric.newBuilder()
+                .setName("client.request.latency")
+                .setHistogram(h)
+                .build();
+
+        var data = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null).metrics();
+        assertEquals(MetricDataType.HISTOGRAM, data.get(0).getType());
+        var point = data.get(0).getHistogramData().getPoints().iterator().next();
+        assertEquals(1L, point.getStartEpochNanos());
+        assertEquals(2L, point.getEpochNanos());
+        assertEquals(3L, point.getCount());
+        assertEquals(30.0, point.getSum());
+        assertEquals(5.0, point.getMin());
+        assertEquals(20.0, point.getMax());
+        assertEquals(List.of(10.0), point.getBoundaries());
+        assertEquals(List.of(1L, 2L), point.getCounts());
+    }
+
+    @Test
+    void drops_and_counts_exponential_histogram() throws Exception {
+        Metric m = Metric.newBuilder()
+                .setName("client.exp")
+                .setExponentialHistogram(io.opentelemetry.proto.metrics.v1.ExponentialHistogram.newBuilder()
+                        .addDataPoints(io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint.newBuilder()
+                                .setTimeUnixNano(1L)
+                                .setCount(1L)
+                                .build())
+                        .build())
+                .build();
+
+        var result = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null);
+        assertEquals(0, result.metrics().size());
+        assertEquals(1, result.unsupportedDropped());
+    }
+
+    @Test
+    void drops_and_counts_data_points_whose_value_type_differs_from_the_first() throws Exception {
+        // The OTLP spec requires one consistent value type per metric, but the payload is
+        // untrusted network input and protobuf's oneof doesn't enforce it: reading a mismatched
+        // point through the wrong accessor would silently yield 0. The converter must drop and
+        // count such points instead of exporting corrupted zeros.
+        Metric m = Metric.newBuilder()
+                .setName("client.mixed")
+                .setGauge(Gauge.newBuilder()
+                        .addDataPoints(NumberDataPoint.newBuilder()
+                                .setTimeUnixNano(1L)
+                                .setAsDouble(4.5)
+                                .build())
+                        .addDataPoints(NumberDataPoint.newBuilder()
+                                .setTimeUnixNano(2L)
+                                .setAsInt(7L)
+                                .build())
+                        .addDataPoints(NumberDataPoint.newBuilder()
+                                .setTimeUnixNano(3L)
+                                .setAsDouble(6.5)
+                                .build())
+                        .build())
+                .build();
+
+        var result = CONVERTER.convert(oneMetric(m).toByteArray(), Map.of(), null);
+        assertEquals(1, result.metrics().size());
+        assertEquals(1, result.unsupportedDropped(), "the AS_INT point must be dropped and counted");
+        var points = result.metrics().get(0).getDoubleGaugeData().getPoints();
+        assertEquals(2, points.size());
+        assertTrue(points.stream().allMatch(p -> p.getValue() == 4.5 || p.getValue() == 6.5), "no zero corruption");
+    }
+}

--- a/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsEnricherTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientMetricsEnricherTest.java
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher.ClientIdentity;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ClientMetricsEnricherTest {
+
+    private static io.opentelemetry.proto.resource.v1.Resource clientResource(String key, String value) {
+        return io.opentelemetry.proto.resource.v1.Resource.newBuilder()
+                .addAttributes(KeyValue.newBuilder()
+                        .setKey(key)
+                        .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                        .build())
+                .build();
+    }
+
+    @Test
+    void carries_client_attributes_when_both_toggles_off() {
+        var enricher = new ClientMetricsEnricher(false, false, false, false);
+        io.opentelemetry.sdk.resources.Resource r =
+                enricher.enrich(clientResource("client_instance_id", "abc"), Map.of("kafka.cluster.id", "C1"), null);
+        assertEquals("abc", r.getAttribute(stringKey("client_instance_id")));
+        assertNull(r.getAttribute(stringKey("kafka.cluster.id")));
+    }
+
+    @Test
+    void broker_wins_on_conflict_when_enrich_broker_enabled() {
+        var enricher = new ClientMetricsEnricher(true, false, false, false);
+        io.opentelemetry.sdk.resources.Resource r = enricher.enrich(
+                clientResource("kafka.cluster.id", "SPOOFED"),
+                Map.of("kafka.cluster.id", "REAL", "kafka.node.id", "1"),
+                null);
+        assertEquals("REAL", r.getAttribute(stringKey("kafka.cluster.id")));
+        assertEquals("1", r.getAttribute(stringKey("kafka.node.id")));
+    }
+
+    @Test
+    void adds_client_identity_only_when_toggle_on() {
+        var off = new ClientMetricsEnricher(false, false, false, false);
+        assertNull(
+                off.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity("User:alice", "10.0.0.1", null, null))
+                        .getAttribute(stringKey("kafka.client.principal")));
+
+        var on = new ClientMetricsEnricher(false, true, false, false);
+        io.opentelemetry.sdk.resources.Resource r =
+                on.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity("User:alice", "10.0.0.1", null, null));
+        assertEquals("User:alice", r.getAttribute(stringKey("kafka.client.principal")));
+        assertEquals("10.0.0.1", r.getAttribute(stringKey("kafka.client.address")));
+    }
+
+    @Test
+    void adds_client_id_only_when_enrich_client_id_enabled() {
+        var off = new ClientMetricsEnricher(false, false, false, false);
+        assertNull(off.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, "my-client", null))
+                .getAttribute(stringKey("client_id")));
+
+        var on = new ClientMetricsEnricher(false, false, true, false);
+        io.opentelemetry.sdk.resources.Resource r =
+                on.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, "my-client", null));
+        assertEquals("my-client", r.getAttribute(stringKey("client_id")));
+    }
+
+    @Test
+    void client_id_not_added_when_blank_or_null() {
+        var enricher = new ClientMetricsEnricher(false, false, true, false);
+        assertNull(enricher.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, "", null))
+                .getAttribute(stringKey("client_id")));
+        assertNull(enricher.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, null, null))
+                .getAttribute(stringKey("client_id")));
+    }
+
+    @Test
+    void adds_client_instance_id_only_when_enrich_client_instance_id_enabled() {
+        var off = new ClientMetricsEnricher(false, false, false, false);
+        assertNull(off.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, null, "inst-uuid-123"))
+                .getAttribute(stringKey("client_instance_id")));
+
+        var on = new ClientMetricsEnricher(false, false, false, true);
+        io.opentelemetry.sdk.resources.Resource r =
+                on.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, null, "inst-uuid-123"));
+        assertEquals("inst-uuid-123", r.getAttribute(stringKey("client_instance_id")));
+    }
+
+    @Test
+    void client_instance_id_not_added_when_blank_or_null() {
+        var enricher = new ClientMetricsEnricher(false, false, false, true);
+        assertNull(enricher.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, null, ""))
+                .getAttribute(stringKey("client_instance_id")));
+        assertNull(enricher.enrich(clientResource("a", "b"), Map.of(), new ClientIdentity(null, null, null, null))
+                .getAttribute(stringKey("client_instance_id")));
+    }
+
+    @Test
+    void stringify_converts_non_string_scalars() {
+        assertEquals(
+                "42",
+                ClientMetricsEnricher.stringify(
+                        AnyValue.newBuilder().setIntValue(42).build()));
+        assertEquals(
+                "true",
+                ClientMetricsEnricher.stringify(
+                        AnyValue.newBuilder().setBoolValue(true).build()));
+        assertEquals("", ClientMetricsEnricher.stringify(AnyValue.getDefaultInstance())); // VALUE_NOT_SET
+    }
+}

--- a/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryForwarderTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryForwarderTest.java
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.metrics.v1.Gauge;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ClientTelemetryForwarderTest {
+
+    /** Captures exported metrics; can be told to fail to exercise the export-failure counter. */
+    static final class CapturingExporter implements MetricExporter {
+        final List<MetricData> exported = java.util.Collections.synchronizedList(new ArrayList<>());
+        volatile boolean fail = false;
+
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            if (fail) return CompletableResultCode.ofFailure();
+            exported.addAll(metrics);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+    }
+
+    static byte[] oneGauge() {
+        return MetricsData.newBuilder()
+                .addResourceMetrics(ResourceMetrics.newBuilder()
+                        .addScopeMetrics(ScopeMetrics.newBuilder()
+                                .setScope(InstrumentationScope.newBuilder()
+                                        .setName("client")
+                                        .build())
+                                .addMetrics(Metric.newBuilder()
+                                        .setName("client.count")
+                                        .setGauge(Gauge.newBuilder()
+                                                .addDataPoints(NumberDataPoint.newBuilder()
+                                                        .setTimeUnixNano(1L)
+                                                        .setAsDouble(1.0)
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build()
+                .toByteArray();
+    }
+
+    static ClientTelemetryForwarder newForwarder(MetricExporter exporter, int capacity) {
+        return new ClientTelemetryForwarder(
+                exporter,
+                new ClientMetricsConverter(new ClientMetricsEnricher(false, false, false, false)),
+                capacity,
+                1000L);
+    }
+
+    private static void awaitEquals(long expected, java.util.function.LongSupplier actual) throws InterruptedException {
+        for (int i = 0; i < 200 && actual.getAsLong() != expected; i++) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+        assertEquals(expected, actual.getAsLong());
+    }
+
+    @Test
+    void forwards_converted_metrics_to_exporter() throws Exception {
+        var exporter = new CapturingExporter();
+        var fwd = newForwarder(exporter, 16);
+        fwd.start();
+        try {
+            fwd.submit(oneGauge(), null);
+            awaitEquals(1, fwd::forwardedCount);
+            assertEquals("client.count", exporter.exported.get(0).getName());
+            assertEquals(1, fwd.receivedCount());
+            assertEquals(0, fwd.droppedCount());
+        } finally {
+            fwd.stop();
+        }
+    }
+
+    @Test
+    void counts_export_failure() throws Exception {
+        var exporter = new CapturingExporter();
+        exporter.fail = true;
+        var fwd = newForwarder(exporter, 16);
+        fwd.start();
+        try {
+            fwd.submit(oneGauge(), null);
+            awaitEquals(1, fwd::droppedCount);
+            assertEquals(0, fwd.forwardedCount());
+        } finally {
+            fwd.stop();
+        }
+    }
+
+    @Test
+    void drops_when_queue_full() {
+        // Capacity 1, never started, so nothing drains: first submit fills the queue, rest are dropped.
+        var fwd = newForwarder(new CapturingExporter(), 1);
+        AtomicInteger accepted = new AtomicInteger();
+        for (int i = 0; i < 5; i++) {
+            if (fwd.submit(oneGauge(), null)) accepted.incrementAndGet();
+        }
+        assertEquals(1, accepted.get());
+        assertTrue(fwd.droppedCount() >= 4);
+    }
+
+    @Test
+    void submit_after_stop_is_rejected_and_counted_as_dropped() throws Exception {
+        var fwd = newForwarder(new CapturingExporter(), 16);
+        fwd.start();
+        fwd.stop();
+        // The drain thread is gone: an unguarded offer would park the payload invisibly on a
+        // dead queue — neither forwarded nor dropped — until the queue filled. It must instead
+        // be rejected and counted as dropped immediately.
+        assertFalse(fwd.submit(oneGauge(), null));
+        assertEquals(1, fwd.receivedCount());
+        assertEquals(1, fwd.droppedCount());
+        assertEquals(0, fwd.forwardedCount());
+    }
+
+    @Test
+    void counts_unsupported_metrics_separately_from_payload_drops() throws Exception {
+        var exporter = new CapturingExporter();
+        var fwd = newForwarder(exporter, 16);
+        fwd.start();
+        try {
+            byte[] payload = MetricsData.newBuilder()
+                    .addResourceMetrics(ResourceMetrics.newBuilder()
+                            .addScopeMetrics(ScopeMetrics.newBuilder()
+                                    .setScope(InstrumentationScope.newBuilder()
+                                            .setName("client")
+                                            .build())
+                                    .addMetrics(Metric.newBuilder()
+                                            .setName("client.exp")
+                                            .setExponentialHistogram(
+                                                    io.opentelemetry.proto.metrics.v1.ExponentialHistogram.newBuilder()
+                                                            .addDataPoints(io.opentelemetry.proto.metrics.v1
+                                                                    .ExponentialHistogramDataPoint.newBuilder()
+                                                                    .setTimeUnixNano(1L)
+                                                                    .setCount(1L)
+                                                                    .build())
+                                                            .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build()
+                    .toByteArray();
+            fwd.submit(payload, null);
+            awaitEquals(1, fwd::unsupportedMetricsDroppedCount);
+            assertEquals(0, fwd.forwardedCount());
+            assertEquals(0, fwd.droppedCount());
+        } finally {
+            fwd.stop();
+        }
+    }
+}

--- a/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryReceiverImplTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/clienttelemetry/ClientTelemetryReceiverImplTest.java
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.clienttelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher.ClientIdentity;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.telemetry.ClientTelemetryPayload;
+import org.junit.jupiter.api.Test;
+
+class ClientTelemetryReceiverImplTest {
+
+    /** Test double capturing what the receiver hands to the forwarder. */
+    static final class Sink implements ClientTelemetryReceiverImpl.Submitter {
+        final AtomicReference<byte[]> payload = new AtomicReference<>();
+        final AtomicReference<ClientIdentity> identity = new AtomicReference<>();
+
+        @Override
+        public boolean submit(byte[] p, ClientIdentity id) {
+            payload.set(p);
+            identity.set(id);
+            return true;
+        }
+    }
+
+    private static final Uuid FIXED_UUID = Uuid.randomUuid();
+
+    private static ClientTelemetryPayload payloadOf(byte[] bytes) {
+        ClientTelemetryPayload p = mock(ClientTelemetryPayload.class);
+        when(p.data()).thenReturn(ByteBuffer.wrap(bytes));
+        when(p.clientInstanceId()).thenReturn(FIXED_UUID);
+        return p;
+    }
+
+    private static AuthorizableRequestContext ctx() throws Exception {
+        AuthorizableRequestContext c = mock(AuthorizableRequestContext.class);
+        when(c.principal()).thenReturn(new KafkaPrincipal("User", "alice"));
+        when(c.clientAddress()).thenReturn(InetAddress.getByName("10.0.0.7"));
+        when(c.clientId()).thenReturn("my-client");
+        return c;
+    }
+
+    @Test
+    void copies_payload_and_omits_principal_address_when_disabled() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, false);
+        byte[] src = {1, 2, 3};
+        ByteBuffer buf = ByteBuffer.wrap(src);
+        ClientTelemetryPayload p = mock(ClientTelemetryPayload.class);
+        when(p.data()).thenReturn(buf);
+        when(p.clientInstanceId()).thenReturn(FIXED_UUID);
+
+        receiver.exportMetrics(ctx(), p);
+
+        assertArrayEquals(new byte[] {1, 2, 3}, sink.payload.get());
+        // The copy must be independent of the source buffer's backing array.
+        src[0] = 99;
+        assertEquals(1, sink.payload.get()[0]);
+        // Identity is always built now; principal/address are null when captureClientIdentity is false.
+        assertNotNull(sink.identity.get());
+        assertNull(sink.identity.get().principal());
+        assertNull(sink.identity.get().address());
+    }
+
+    @Test
+    void captures_identity_when_enabled() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, true);
+        receiver.exportMetrics(ctx(), payloadOf(new byte[] {4}));
+
+        assertEquals("User:alice", sink.identity.get().principal());
+        assertEquals("10.0.0.7", sink.identity.get().address());
+    }
+
+    @Test
+    void always_captures_client_id_and_instance_id_regardless_of_capture_flag() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, false);
+        receiver.exportMetrics(ctx(), payloadOf(new byte[] {4}));
+
+        assertNotNull(sink.identity.get());
+        assertEquals("my-client", sink.identity.get().clientId());
+        assertEquals(FIXED_UUID.toString(), sink.identity.get().clientInstanceId());
+    }
+
+    @Test
+    void captures_client_id_and_instance_id_also_when_capture_flag_enabled() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, true);
+        receiver.exportMetrics(ctx(), payloadOf(new byte[] {4}));
+
+        assertNotNull(sink.identity.get());
+        assertEquals("my-client", sink.identity.get().clientId());
+        assertEquals(FIXED_UUID.toString(), sink.identity.get().clientInstanceId());
+    }
+
+    @Test
+    void client_id_is_null_when_context_is_null() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, false);
+        ClientTelemetryPayload p = payloadOf(new byte[] {4});
+        receiver.exportMetrics(null, p);
+
+        assertNotNull(sink.identity.get());
+        assertNull(sink.identity.get().clientId());
+    }
+
+    @Test
+    void tolerates_null_payload_data() throws Exception {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, false);
+        ClientTelemetryPayload p = mock(ClientTelemetryPayload.class);
+        when(p.data()).thenReturn(null);
+        // Must not throw on a broker request-handler thread.
+        receiver.exportMetrics(ctx(), p);
+        assertNull(sink.payload.get());
+    }
+
+    @Test
+    void tolerates_null_payload() {
+        var sink = new Sink();
+        var receiver = new ClientTelemetryReceiverImpl(sink, false);
+        receiver.exportMetrics(null, null); // must not throw
+        assertNull(sink.payload.get());
+    }
+}

--- a/src/test/java/dev/monedula/metricsreporter/integration/ClientTelemetryForwarderIntegrationTest.java
+++ b/src/test/java/dev/monedula/metricsreporter/integration/ClientTelemetryForwarderIntegrationTest.java
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Monedula contributors
+package dev.monedula.metricsreporter.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.monedula.metricsreporter.OtlpExporterFactory;
+import dev.monedula.metricsreporter.OtlpMetricReporterConfig;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsConverter;
+import dev.monedula.metricsreporter.clienttelemetry.ClientMetricsEnricher;
+import dev.monedula.metricsreporter.clienttelemetry.ClientTelemetryForwarder;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.metrics.v1.Gauge;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+@Testcontainers
+class ClientTelemetryForwarderIntegrationTest {
+
+    @Container
+    static GenericContainer<?> collector = new GenericContainer<>("otel/opentelemetry-collector-contrib:0.152.0")
+            .withExposedPorts(4317, 4318)
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("otel-collector-test-config.yaml"),
+                    "/etc/otel-collector-config.yaml")
+            .withCommand("--config=/etc/otel-collector-config.yaml")
+            .waitingFor(Wait.forLogMessage(".*Everything is ready.*", 1));
+
+    private static byte[] oneGauge() {
+        return MetricsData.newBuilder()
+                .addResourceMetrics(ResourceMetrics.newBuilder()
+                        .addScopeMetrics(ScopeMetrics.newBuilder()
+                                .setScope(InstrumentationScope.newBuilder()
+                                        .setName("client")
+                                        .build())
+                                .addMetrics(Metric.newBuilder()
+                                        .setName("client.count")
+                                        .setGauge(Gauge.newBuilder()
+                                                .addDataPoints(NumberDataPoint.newBuilder()
+                                                        .setTimeUnixNano(1L)
+                                                        .setAsDouble(1.0)
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build()
+                .toByteArray();
+    }
+
+    private void assertCollectorLogsContain(String... expected) throws InterruptedException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (System.nanoTime() < deadline) {
+            String logs = collector.getLogs();
+            boolean allPresent = true;
+            for (String s : expected) {
+                if (!logs.contains(s)) {
+                    allPresent = false;
+                    break;
+                }
+            }
+            if (allPresent) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        fail("Collector logs did not contain all of "
+                + java.util.Arrays.toString(expected)
+                + "\n"
+                + collector.getLogs());
+    }
+
+    @Test
+    void forwards_client_telemetry_with_broker_identity_enrichment() throws InterruptedException {
+        String endpoint = "http://" + collector.getHost() + ":" + collector.getMappedPort(4317);
+        var cfg = new OtlpMetricReporterConfig(Map.of(
+                "otlp.metric.reporter.endpoint", endpoint,
+                "otlp.metric.reporter.transport", "grpc",
+                // ClientTelemetryForwarder exports on-demand per submitted item, not on a timer, so this
+                // interval has no effect here — it only satisfies config validation (timeout < interval).
+                "otlp.metric.reporter.interval.ms", "60000",
+                "otlp.metric.reporter.timeout.ms", "5000"));
+
+        // Broker enrichment on, client-identity enrichment off: client-identity enrichment is intentionally
+        // out of scope for this test (hence the null clientIdentity passed to submit below).
+        var fwd = new ClientTelemetryForwarder(
+                OtlpExporterFactory.create(cfg),
+                new ClientMetricsConverter(new ClientMetricsEnricher(true, false, false, false)),
+                16,
+                5000L);
+        fwd.setBrokerIdentity(Map.of("kafka.cluster.id", "C1"));
+        fwd.start();
+        try {
+            fwd.submit(oneGauge(), null);
+            assertCollectorLogsContain("client.count", "kafka.cluster.id: Str(C1)");
+        } finally {
+            fwd.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Kafka's `ClientTelemetry` interface so the broker plugin receives the metrics KIP-714 clients push and forwards them to the OpenTelemetry collector — a third metric stream alongside the SPI and Yammer registries.

- **Receiver / forwarder:** each push is copied onto a bounded queue on the request-handler thread (non-blocking, fail-open); a daemon thread converts the OTLP payload to SDK `MetricData` and exports it via its own `MetricExporter`.
- **Enrichment:** broker identity (`kafka_cluster_id` / `kafka_node_id`) and `client_id` by default; `client_instance_id`, principal and address are opt-in. New `otlp.metric.reporter.client.telemetry.enrich.*` config.
- **Self-monitoring:** `clienttelemetry_{received,forwarded,dropped,unsupported_metrics_dropped}_total` and `clienttelemetry_queue_depth`.
- **Fix:** the export-duration self-metric is now `monedula_reporter_export_duration_ms` (dropped the redundant OTLP `ms` unit that caused a doubled `_milliseconds` suffix).
- **Quickstart:** a `demo` sidecar auto-creates a client-metrics subscription and drives traffic; an optional confluent-kafka-python (librdkafka) demo runs behind a compose profile to show cross-library behavior.
- **Dashboards:** producer/consumer client-view Grafana dashboards split panels into **Standard** (any KIP-714 client) vs **Extended** (JVM-only), with cluster/client/topic/group filters.

## Test plan

- [ ] `./gradlew spotlessCheck test` — unit + Testcontainers integration
- [ ] `./gradlew :e2e:test` — KIP-714 e2e asserts client metrics reach Prometheus with broker enrichment
- [ ] `./gradlew shadowJar` — relocated `opentelemetry-proto` / `protobuf-java` bundled (verify SBOM)
- [ ] Quickstart `docker compose up`: client dashboards populate; `--profile librdkafka` shows Standard-only for librdkafka