### PR TITLE
docs: changelog for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-10
+
 ### Added
 
 - KIP-714 client telemetry forwarding: the reporter now implements Kafka's


### PR DESCRIPTION
Prepares the changelog for the **v0.10.0** release.

- Moves the accumulated `## [Unreleased]` entries into a versioned `## [0.10.0] - 2026-07-10` section.
- Adds a fresh empty `## [Unreleased]` heading above it.

Per [RELEASING.md](RELEASING.md), once this merges to `main`, tag the merge commit `v0.10.0` and push the tag to trigger the release workflow.

## Highlights since v0.9.0

- **Added:** KIP-714 client telemetry forwarding (third metric stream + client dashboards + quickstart demo clients).
- **Changed:** transport-aware default OTLP endpoint; SPI `*-total` counters exported as monotonic Sums.
- **Fixed:** export-duration metric rename, allow-list backreference handling, export survives `Error` on a tick, bounded caches under churn, stable counter start time across `contextChange`, HTTP path normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)