### PR TITLE
docs: document installing the prebuilt plugin JAR from registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,56 @@ multiplying e2e by every cell would add runtime without adding coverage.
 
 ## Installation
 
-```bash
-# Build the shadow JAR
-./gradlew shadowJar
+The plugin ships as a single relocated ("shadow") JAR — drop it anywhere on
+Kafka's classpath (the broker's `libs/` directory is the usual spot). Released
+versions are published to **Maven Central**, **GitHub Packages**, and each
+**GitHub Release**, so there's no need to build from source. Prefer to build it
+yourself anyway? See [Building from source](#building-from-source).
 
+### Download the plugin JAR
+
+Pick whichever source fits your environment. Replace `0.10.0` with the
+[latest release](https://github.com/monedula-dev/monedula-metrics-reporter/releases/latest)
+if a newer one exists.
+
+**Maven Central** — no authentication, direct download:
+
+```bash
+VERSION=0.10.0
+curl -L -o monedula-metrics-reporter-${VERSION}.jar \
+  https://repo1.maven.org/maven2/dev/monedula/monedula-metrics-reporter/${VERSION}/monedula-metrics-reporter-${VERSION}.jar
+```
+
+The published main artifact is the relocated shadow JAR — the same file the
+build produces — under coordinates `dev.monedula:monedula-metrics-reporter`, so
+tooling that resolves JARs for you (Coursier, `mvn dependency:get`, etc.) can
+fetch it directly:
+
+```bash
+mvn dependency:get -Dartifact=dev.monedula:monedula-metrics-reporter:0.10.0
+```
+
+**GitHub Release** — the same JAR, plus a CycloneDX SBOM and Sigstore
+`.sig`/`.pem` provenance files you can verify with `cosign` (see
+[Verifying a release artifact](RELEASING.md#verifying-a-release-artifact-for-consumers)):
+
+```bash
+VERSION=0.10.0
+curl -L -o monedula-metrics-reporter-${VERSION}.jar \
+  https://github.com/monedula-dev/monedula-metrics-reporter/releases/download/v${VERSION}/monedula-metrics-reporter-${VERSION}.jar
+```
+
+**GitHub Packages** — the same coordinates are also served from
+<https://github.com/orgs/monedula-dev/packages?repo_name=monedula-metrics-reporter>.
+GitHub's Maven registry requires a personal access token (`read:packages`) to
+resolve, so this suits builds already authenticated against GitHub Packages;
+otherwise reach for Maven Central above.
+
+### Put it on Kafka's classpath
+
+```bash
 # Copy into Kafka's libs/ directory (or anywhere on Kafka's classpath)
-cp build/libs/monedula-metrics-reporter-0.1.0.jar $KAFKA_HOME/libs/
+cp monedula-metrics-reporter-0.10.0.jar $KAFKA_HOME/libs/
 ```
 
 Then add to `server.properties` (broker) or producer/consumer config:


### PR DESCRIPTION
## What

Reworks the README **Installation** section to document downloading the
prebuilt plugin JAR from the public artifact registries, instead of leading
with a from-source build.

Fixes #7.

## Why

The reporter is published to Maven Central, GitHub Packages, and every GitHub
Release (verified: `dev.monedula:monedula-metrics-reporter:0.10.0` resolves on
`repo1.maven.org`), yet the README's Installation section opened with
`./gradlew shadowJar` and never told users the artifact already exists. Most
operators just want to drop the JAR on Kafka's classpath — no build required.

## Changes

- Installation now leads with **Download the plugin JAR**, covering three sources:
  - **Maven Central** — no-auth `curl` one-liner plus `dev.monedula:monedula-metrics-reporter` coordinates / `mvn dependency:get`.
  - **GitHub Release** — same JAR with CycloneDX SBOM + Sigstore `.sig`/`.pem` provenance (links to the existing `cosign` verification steps in `RELEASING.md`).
  - **GitHub Packages** — noting the `read:packages` token requirement.
- Keeps build-from-source as an explicit opt-in, linking to the existing **Building from source** section.
- The install step now copies the downloaded `0.10.0` JAR (the current release) rather than the local-build default filename.

## Verification

- Every documented URL returns `200` (Maven Central JAR, GitHub Release asset, `releases/latest`).
- Both cross-reference anchors resolve (`RELEASING.md#verifying-a-release-artifact-for-consumers`, `README.md#building-from-source`).

Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)