### PR TITLE
build: test against the latest Kafka patch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['17', '21']
-        kafka: ['3.7.0', '3.9.0', '4.2.0', '4.3.0']
+        kafka: ['3.7.2', '3.9.2', '4.2.1', '4.3.1']
     name: test (JDK ${{ matrix.java }} / Kafka ${{ matrix.kafka }})
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ For the longer product and engineering rationale, see:
 CI builds the shadow JAR and runs the full unit + integration suite against the
 full Cartesian product of the JDK and Kafka versions below:
 
-| | Kafka 3.7.0 | Kafka 3.9.0 | Kafka 4.2.0 | Kafka 4.3.0 |
+| | Kafka 3.7.2 | Kafka 3.9.2 | Kafka 4.2.1 | Kafka 4.3.1 |
 |---|:---:|:---:|:---:|:---:|
 | **JDK 17** | ✓ | ✓ | ✓ | ✓ |
 | **JDK 21** | ✓ | ✓ | ✓ | ✓ |
 
 The end-to-end test (Kafka + OTel collector + Prometheus via Testcontainers)
-runs once per CI build against the default Kafka version (`4.2.0`) — the
+runs once per CI build against the default Kafka version (`4.2.1`) — the
 contact surface with Kafka is already covered by the matrix above, so
 multiplying e2e by every cell would add runtime without adding coverage.
 

--- a/e2e/src/test/java/dev/monedula/metricsreporter/e2e/KafkaOtlpE2ETest.java
+++ b/e2e/src/test/java/dev/monedula/metricsreporter/e2e/KafkaOtlpE2ETest.java
@@ -129,7 +129,7 @@ class KafkaOtlpE2ETest {
                     .waitingFor(Wait.forHttp("/-/ready").forPort(9090));
             prometheus.start();
 
-            kafka = new GenericContainer<>("apache/kafka:4.2.0")
+            kafka = new GenericContainer<>("apache/kafka:4.2.1")
                     .withNetwork(network)
                     .withNetworkAliases("kafka")
                     .withEnv("KAFKA_NODE_ID", "1")
@@ -353,7 +353,7 @@ class KafkaOtlpE2ETest {
                 // returns an empty GetTelemetrySubscriptions response and clients don't push.
                 // ConfigResource.Type.CLIENT_METRICS is available since Kafka 3.7 (KIP-714).
                 //
-                // The "metrics" value MUST be "*" to subscribe to ALL client metrics. Kafka 4.2.0's
+                // The "metrics" value MUST be "*" to subscribe to ALL client metrics. Kafka 4.2.1's
                 // ClientMetricsConfigs defines ALL_SUBSCRIBED_METRICS = "*" and METRICS_DEFAULT =
                 // List.of() (empty). An empty string therefore selects NO metrics, so clients
                 // complete the GetTelemetrySubscriptions handshake but never push — which is exactly

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kafkaVersion=4.2.0
+kafkaVersion=4.2.1
 otelVersion=1.40.0
 otelInstrumentationVersion=2.7.0-alpha
 otelProtoVersion=1.7.0-alpha

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # is set explicitly for __consumer_offsets and the transaction log so they
   # come up cleanly — the Kafka defaults assume a multi-broker cluster.
   kafka1:
-    image: apache/kafka:4.2.0
+    image: apache/kafka:4.2.1
     hostname: kafka1
     environment:
       KAFKA_NODE_ID: 1
@@ -31,7 +31,7 @@ services:
       - otel-collector
 
   kafka2:
-    image: apache/kafka:4.2.0
+    image: apache/kafka:4.2.1
     hostname: kafka2
     environment:
       KAFKA_NODE_ID: 2
@@ -57,7 +57,7 @@ services:
       - otel-collector
 
   kafka3:
-    image: apache/kafka:4.2.0
+    image: apache/kafka:4.2.1
     hostname: kafka3
     environment:
       KAFKA_NODE_ID: 3
@@ -124,7 +124,7 @@ services:
   # collector, populating the client dashboards. Also generates broker-side
   # traffic for the existing Production/Consumption dashboards.
   demo:
-    image: apache/kafka:4.2.0
+    image: apache/kafka:4.2.1
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
@@ -166,7 +166,7 @@ services:
   # can vanish after a broker recreate. confluent-kafka-python's AdminClient cannot create
   # a CLIENT_METRICS subscription, hence the apache/kafka CLI image here.
   demo-librdkafka-init:
-    image: apache/kafka:4.2.0
+    image: apache/kafka:4.2.1
     profiles: ["librdkafka"]
     entrypoint: ["/bin/bash", "-c"]
     command:


### PR DESCRIPTION
Bump every Kafka version the CI matrix exercises to the newest patch in its line: 3.7.2, 3.9.2, 4.2.1, 4.3.1. The supported surface is now tested against the releases users actually run rather than the initial release of each line.

Also move the default kafkaVersion from 4.2.0 to 4.2.1. The default is the compile/publish target for the shadow JAR and the version :e2e resolves, so leaving it behind would have shipped a JAR built against a version no matrix cell covers. The e2e broker image and the quickstart compose stack follow the same pin.

